### PR TITLE
Add Cursor Cloud development environment setup

### DIFF
--- a/.ai-context/AGENTS.md
+++ b/.ai-context/AGENTS.md
@@ -39,3 +39,43 @@
 ## 8) Documentation Discipline
 - Keep `constitution.md`, `glossary.md`, and `architectureoverview.md` aligned with code changes.
 - Update `.ai-context` files if dependencies change.
+
+## Cursor Cloud specific instructions
+
+### Service overview
+
+The application runs as a Docker Compose stack from `src/docker-compose.yml`. Core services: **postgres** (PostGIS), **redis**, **keycloak**, **backend** (FastAPI/uvicorn), **celery-worker**, **frontend** (Next.js), **nginx-gateway** (reverse proxy on port 80). Optional: **ollama** (AI), **wims-suricata** (IDS).
+
+### Starting the stack
+
+```bash
+cd src && docker compose up --build -d
+```
+
+A `docker-compose.override.yml` is provided in `src/` to stub out Ollama and Suricata (both optional) and remove cgroup resource limits that fail in Cloud Agent VMs. The override also removes the backend's dependency on Ollama. Do not delete this file.
+
+### Cgroup / resource-limit caveat
+
+Docker containers with `deploy.resources.limits` (CPU/memory) will fail with a cgroup error in the Cloud Agent VM. The override file uses `!reset` YAML tags to clear these. If adding new services with resource limits, add corresponding `!reset` entries in the override.
+
+### Lint, test, and build commands
+
+See `README.md` for canonical commands. Quick reference:
+- **Frontend lint**: `cd src/frontend && npm run lint` (pre-existing lint errors exist — 102 errors, mostly `@typescript-eslint/no-explicit-any`)
+- **Frontend tests**: `cd src/frontend && npx vitest run` (some theme-audit tests fail pre-existing; set `NEXT_PUBLIC_BASE_URL=http://localhost` for login tests)
+- **Backend tests**: `cd src/backend && source .venv/bin/activate && pytest -v --ignore=tests/test_fire_incident_location.py` (55 pass, 33 errors from integration tests needing Redis/Postgres; `test_fire_incident_location.py` has a broken import `from backend.models...` — skip it)
+- **Frontend build**: `cd src/frontend && npm run build`
+
+### Local development (outside Docker)
+
+- **Node.js 20** via nvm: `source ~/.nvm/nvm.sh && nvm use 20`
+- **Python 3.11** venv: `source src/backend/.venv/bin/activate`
+- Frontend deps: `cd src/frontend && npm ci`
+- Backend deps: `cd src/backend && pip install -r requirements.txt`
+
+### Access URLs (when Docker stack is running)
+
+- Frontend: http://localhost
+- Keycloak admin: http://localhost/auth (admin / admin)
+- Backend API: http://localhost/api
+- Public endpoint (no auth): `POST /api/civilian/reports` with JSON `{latitude, longitude, description}`

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -1,0 +1,21 @@
+services:
+  ollama:
+    image: alpine:3.20
+    entrypoint: ["sh", "-c", "tail -f /dev/null"]
+    volumes: !reset []
+    deploy: !reset {}
+
+  backend:
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      keycloak:
+        condition: service_started
+
+  wims-suricata:
+    image: alpine:3.20
+    entrypoint: ["sh", "-c", "tail -f /dev/null"]
+    volumes: !reset []
+    command: !override ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for the WIMS-BFP project.

### Changes
- **`src/docker-compose.override.yml`**: Override file that stubs out optional services (Ollama, Suricata) and removes `deploy.resources.limits` that cause cgroup failures in Cloud Agent VMs. Uses Docker Compose `!reset` YAML tags to cleanly clear inherited resource limits.
- **`.ai-context/AGENTS.md`**: Added `## Cursor Cloud specific instructions` section with service overview, startup commands, known caveats (cgroup limits, pre-existing test failures), and development workflow reference.

### What was verified
- Docker Compose stack starts successfully (postgres, redis, keycloak, backend, celery-worker, frontend, nginx-gateway)
- Frontend loads at http://localhost (login page renders)
- Keycloak SSO is accessible at http://localhost/auth
- Backend API is responsive; civilian fire report submission (`POST /api/civilian/reports`) works end-to-end
- Frontend lint runs (`npm run lint`)
- Frontend tests run (`npx vitest run`)
- Backend tests run (`pytest -v`)

### Pre-existing issues (not introduced by this PR)
- Frontend lint: 102 errors (mostly `@typescript-eslint/no-explicit-any`)
- Frontend tests: 10 failures in theme-audit/design-determinism tests
- Backend tests: 33 errors in integration tests (require running Redis/Postgres); 1 broken import in `test_fire_incident_location.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2547294c-f88c-41f6-8472-33fc4f44ce3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2547294c-f88c-41f6-8472-33fc4f44ce3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

