### PR TITLE
fix(CD): pass OIDC build args to docker buildx

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,6 +55,20 @@ jobs:
             type=sha,prefix=
             type=raw,value=latest
 
+      # -------------------------------------------------------------------------
+      # Build args
+      # NOTE: These are PLACEHOLDERS. Update before production deployment.
+      # See: https://github.com/x1n4te/WIMS-BFP-PROTOTYPE/issues/TBD
+      # -------------------------------------------------------------------------
+      - name: Set placeholder envs (frontend only)
+        if: matrix.image == 'wims-frontend'
+        run: |
+          echo "NEXT_PUBLIC_AUTH_API_URL=http://localhost/auth" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_BASE_URL=http://localhost:3000" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_API_URL=http://localhost:8000" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_OIDC_CLIENT_ID=wims-web" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_OIDC_REDIRECT_URI=http://localhost:3000/callback" >> $GITHUB_ENV
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -64,6 +78,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            NEXT_PUBLIC_AUTH_API_URL=${{ vars.NEXT_PUBLIC_AUTH_API_URL || 'http://localhost/auth' }}
+            NEXT_PUBLIC_BASE_URL=${{ vars.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000' }}
+            NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL || 'http://localhost:8000' }}
+            NEXT_PUBLIC_OIDC_CLIENT_ID=${{ vars.NEXT_PUBLIC_OIDC_CLIENT_ID || 'wims-web' }}
+            NEXT_PUBLIC_OIDC_REDIRECT_URI=${{ vars.NEXT_PUBLIC_OIDC_REDIRECT_URI || 'http://localhost:3000/callback' }}
 
   # ===========================================================================
   # NOTIFY — build summary


### PR DESCRIPTION
## Summary

Fixes CI/CD failure on  where the Docker build step for the frontend was missing all  OIDC build arguments.

**Error:** `OIDC Authority URL is undefined` — Next.js prerendering of `/admin` page failed at module evaluation because `NEXT_PUBLIC_AUTH_API_URL` was never passed to `docker buildx`.

## Changes

- ****: Added `build-args` block to `docker/build-push-action` with 5 OIDC env vars
- Values default to localhost placeholders (safe for local dev)
- Reads from GitHub Actions variables if set: `vars.NEXT_PUBLIC_AUTH_API_URL` etc.

## Production Blocking

The localhost defaults are NOT production-safe. See **Issue #80** for the list of env vars that must be configured as GitHub Actions repository variables before the CD pipeline is production-ready.

## Testing

1. Create a test PR to `fix/cd-oidc-build-args` to trigger CI
2. Confirm the frontend Docker build completes without the `OIDC Authority URL is undefined` error
3. After merge to master, confirm CD run succeeds