### PR TITLE
fix(admin): admin user onboarding — RLS context fix + missing contact_number column

### DIFF
--- a/src/backend/api/routes/admin.py
+++ b/src/backend/api/routes/admin.py
@@ -92,7 +92,7 @@ def create_user(
     body: UserCreate,
     request: Request,
     _admin: Annotated[dict, Depends(get_system_admin)],
-    db: Annotated[Session, Depends(get_db_with_rls)],
+    db: Annotated[Session, Depends(get_db)],
 ):
     """
     Onboard a new user.
@@ -143,6 +143,15 @@ def create_user(
                 status_code=422,
                 detail=f"Region ID {body.assigned_region_id} does not exist. Please select a valid region.",
             )
+
+    # --- Set RLS context so wims.current_user_role() returns SYSTEM_ADMIN during INSERT ---
+    # get_db() (not get_db_with_rls) is used above because the postgres service-account
+    # session has no Keycloak JWT — wims.current_user_id would be NULL and RLS would block
+    # the insert with 'ANONYMOUS' role.  We explicitly set it here using a SECURITY DEFINER
+    # helper so the INSERT policy (wims.current_user_role() IN ('SYSTEM_ADMIN')) passes.
+    db.execute(
+        text("SELECT wims.exec_as_system_admin(:uid)"), {"uid": _admin["user_id"]}
+    )
 
     # --- Insert into wims.users ---
     try:

--- a/src/backend/services/keycloak_admin.py
+++ b/src/backend/services/keycloak_admin.py
@@ -11,7 +11,7 @@ import logging
 import secrets
 import string
 
-from keycloak import KeycloakAdmin, KeycloakOpenIDConnection
+from keycloak import KeycloakAdmin, KeycloakOpenID
 from keycloak.exceptions import KeycloakError
 
 logger = logging.getLogger("wims.keycloak_admin")
@@ -49,16 +49,21 @@ def _get_admin_client() -> KeycloakAdmin:
     Return a KeycloakAdmin instance authenticated via the Keycloak master admin
     user. This avoids service-account permission issues and works reliably across
     all Keycloak versions.
+
+    Uses KeycloakOpenID.token() for direct access grant against the master realm,
+    then passes the token to KeycloakAdmin targeting the bfp realm.
     """
-    connection = KeycloakOpenIDConnection(
+    oidc = KeycloakOpenID(
         server_url=_KC_BASE_URL,
-        username=_KC_ADMIN_USER,
-        password=_KC_ADMIN_PASSWORD,
-        realm_name=_KC_REALM,
-        user_realm_name="master",
-        verify=True,
+        realm_name="master",
+        client_id="admin-cli",
     )
-    return KeycloakAdmin(connection=connection)
+    token = oidc.token(_KC_ADMIN_USER, _KC_ADMIN_PASSWORD)
+    return KeycloakAdmin(
+        server_url=_KC_BASE_URL,
+        realm_name=_KC_REALM,
+        token=token,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       - KEYCLOAK_ADMIN_CLIENT_ID=${KEYCLOAK_ADMIN_CLIENT_ID}
       - KEYCLOAK_ADMIN_CLIENT_SECRET=${KEYCLOAK_ADMIN_CLIENT_SECRET}
       - KEYCLOAK_ADMIN_USER=admin
-      - KEYCLOAK_ADMIN_PASSWORD=***
+      - KEYCLOAK_ADMIN_PASSWORD=admin
       - OLLAMA_URL=http://ollama:11434
     volumes:
       - incident_attachments_data:/app/storage

--- a/src/postgres-init/03_users.sql
+++ b/src/postgres-init/03_users.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS wims.users (
   username VARCHAR NOT NULL UNIQUE,
   role VARCHAR NOT NULL,
   assigned_region_id INTEGER REFERENCES wims.ref_regions(region_id),
+  contact_number    VARCHAR(20),
   is_active BOOLEAN DEFAULT TRUE,
   mfa_enabled BOOLEAN DEFAULT FALSE,
   last_login TIMESTAMPTZ,

--- a/src/postgres-init/09_rls_helpers.sql
+++ b/src/postgres-init/09_rls_helpers.sql
@@ -51,4 +51,33 @@ AS $$
   SELECT wims.current_user_region_id()
 $$;
 
+-- set_current_user_uuid: sets the wims.current_user_id GUC directly in the session.
+-- Used by admin-write routes (e.g. create_user) where the route authenticates via
+-- Keycloak JWT / get_system_admin, but the postgres service-account session has no
+-- GUC — causing current_user_role() to return 'ANONYMOUS' and RLS to block the write.
+-- SECURITY DEFINER so it bypasses FORCE ROW LEVEL SECURITY on wims.users.
+CREATE OR REPLACE FUNCTION wims.set_current_user_uuid(uid uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  PERFORM set_config('wims.current_user_id', uid::text, true);
+END;
+$$;
+
+-- exec_as_system_admin: convenience wrapper that sets GUC + role cache for a given
+-- user_id so RLS policies (which use wims.current_user_uuid() and
+-- wims.current_user_role()) evaluate correctly under the postgres service account.
+-- The session's transaction will use this context for all RLS checks.
+CREATE OR REPLACE FUNCTION wims.exec_as_system_admin(uid uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  PERFORM set_config('wims.current_user_id', uid::text, true);
+END;
+$$;
+
 COMMIT;


### PR DESCRIPTION
Two bugs were blocking admin user creation:

1. FORCE ROW LEVEL SECURITY on wims.users applies to ALL sessions
   including the postgres service account. get_db_with_rls() was setting
   wims.current_user_id from the *admin's* request.state (a different
   SQLAlchemy session/DB connection), so the service-account session
   doing the INSERT had NULL GUC → current_user_role() returned
   'ANONYMOUS' → users_admin_insert policy blocked the write.

   Fix: switch create_user to get_db() (no RLS context on the route
   session), then explicitly call wims.exec_as_system_admin(uid) —
   a SECURITY DEFINER helper that sets the GUC directly via
   set_config('wims.current_user_id', uid::text, true) so RLS policies
   evaluate correctly under the postgres service account.

2. contact_number column was absent from wims.users schema.
   The Pydantic model and INSERT statement referenced it but
   03_users.sql never defined it — causing a schema mismatch error
   before the INSERT ever reached RLS evaluation.

   Fix: add contact_number VARCHAR(20) to 03_users.sql and ALTER
   the running database to add it immediately.

3. keycloak_admin.py was using KeycloakOpenIDConnection (broken in
   python-keycloak 7.1.1). Switched to KeycloakOpenID.token() +
   KeycloakAdmin(token=...) which is the correct working pattern.

4. docker-compose.yml KEYCLOAK_ADMIN_PASSWORD was literally "***"
   instead of "admin", preventing Keycloak admin operations.
