### PR TITLE
feat(#68): Suricata HIGH-severity alerts auto-create DRAFT security incidents

### DIFF
--- a/src/backend/services/suricata_ingestion.py
+++ b/src/backend/services/suricata_ingestion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import uuid
 
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -14,6 +15,14 @@ logger = logging.getLogger(__name__)
 # In-memory position tracking for tail behavior (path -> byte offset).
 # Optional: migrate to Redis for multi-worker persistence.
 _eve_file_positions: dict[str, int] = {}
+
+# Service account for security incident auto-creation
+_SVC_SURICATA_UUID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+# Default location: BFP HQ Manila
+_BFP_HQ_LONGITUDE = 121.0232
+_BFP_HQ_LATITUDE = 14.5906
+# Default region: NCR
+_DEFAULT_REGION_ID = 1
 
 
 def parse_eve_alert_line(line: str) -> dict | None:
@@ -58,23 +67,105 @@ def eve_to_threat_log_row(ev: dict, *, raw_payload: str = "") -> dict:
     }
 
 
-def _insert_row(db: Session, row: dict) -> None:
-    """Insert a threat log row via raw SQL (schema uses timestamp, destination_ip)."""
-    db.execute(
+def _insert_row(db: Session, row: dict) -> int | None:
+    """Insert a threat log row via raw SQL. Returns the inserted log_id."""
+    result = db.execute(
         text("""
             INSERT INTO wims.security_threat_logs
                 (source_ip, destination_ip, suricata_sid, severity_level, raw_payload)
             VALUES
                 (:source_ip, :destination_ip, :suricata_sid, :severity_level, :raw_payload)
+            RETURNING log_id
         """),
         row,
     )
+    return result.scalar() or None
+
+
+def _security_incident_exists(db, log_id: int) -> bool:
+    """Check if a fire incident already exists for this security alert."""
+    row = db.execute(
+        text("""
+            SELECT 1 FROM wims.fire_incidents
+            WHERE security_alert_id = :log_id
+            LIMIT 1
+        """),
+        {"log_id": log_id},
+    ).fetchone()
+    return row is not None
+
+
+def _create_security_incident(
+    db,
+    log_id: int,
+    source_ip: str,
+    suricata_sid: int,
+    raw_payload: str,
+) -> int:
+    """
+    Auto-create a DRAFT fire incident from a HIGH-severity Suricata alert.
+    Uses svc_suricata service account and BFP HQ as default location.
+    Returns the new incident_id.
+    """
+    result = db.execute(
+        text("""
+            INSERT INTO wims.fire_incidents
+                (encoder_id, region_id, location, verification_status,
+                 security_alert_id)
+            VALUES
+                (:encoder_id, :region_id,
+                 ST_SetSRID(ST_MakePoint(:lon, :lat), 4326),
+                 'DRAFT',
+                 :log_id)
+            RETURNING incident_id
+        """),
+        {
+            "encoder_id": _SVC_SURICATA_UUID,
+            "region_id": _DEFAULT_REGION_ID,
+            "lon": _BFP_HQ_LONGITUDE,
+            "lat": _BFP_HQ_LATITUDE,
+            "log_id": log_id,
+        },
+    )
+    incident_id = result.fetchone()[0]
+
+    db.execute(
+        text("""
+            INSERT INTO wims.incident_nonsensitive_details
+                (incident_id, general_category, alarm_level, fire_station_name)
+            VALUES
+                (:iid, 'SECURITY', 'ALERT',
+                 :station_name)
+        """),
+        {
+            "iid": incident_id,
+            "station_name": f"Auto-detected: SID={suricata_sid} SRC={source_ip}",
+        },
+    )
+
+    db.execute(
+        text("""
+            INSERT INTO wims.incident_verification_history
+                (target_type, target_id, action_by_user_id,
+                 previous_status, new_status, comments)
+            VALUES
+                ('OFFICIAL', :iid, :uid, 'DRAFT', 'DRAFT',
+                 'Auto-created from Suricata HIGH severity alert')
+        """),
+        {
+            "iid": incident_id,
+            "uid": _SVC_SURICATA_UUID,
+        },
+    )
+
+    return incident_id
 
 
 def ingest_eve_file(path: str, *, db_session: Session | None = None) -> int:
     """
     Read EVE file (tail from last position), parse alert lines, insert into security_threat_logs.
-    Returns number of rows inserted.
+    For HIGH severity alerts, auto-create a DRAFT fire incident.
+    Returns number of rows inserted into security_threat_logs.
     """
     if not os.path.isfile(path):
         logger.warning("EVE file not found: %s", path)
@@ -88,7 +179,6 @@ def ingest_eve_file(path: str, *, db_session: Session | None = None) -> int:
         position = _eve_file_positions.get(path, 0)
         file_size = os.path.getsize(path)
         if file_size < position:
-            # File rotated or truncated
             position = 0
 
         inserted = 0
@@ -100,8 +190,30 @@ def ingest_eve_file(path: str, *, db_session: Session | None = None) -> int:
                 if ev is None:
                     continue
                 row = eve_to_threat_log_row(ev, raw_payload=line)
-                _insert_row(db, row)
-                inserted += 1
+                log_id = _insert_row(db, row)
+                if log_id is not None:
+                    inserted += 1
+                    if row.get("severity_level") == "HIGH":
+                        if not _security_incident_exists(db, log_id):
+                            try:
+                                incident_id = _create_security_incident(
+                                    db,
+                                    log_id=log_id,
+                                    source_ip=row.get("source_ip", "unknown"),
+                                    suricata_sid=row.get("suricata_sid", 0),
+                                    raw_payload=row.get("raw_payload", ""),
+                                )
+                                logger.info(
+                                    "Auto-created security incident %s from log_id %s",
+                                    incident_id,
+                                    log_id,
+                                )
+                            except Exception as e:
+                                logger.error(
+                                    "Failed to auto-create incident from log_id %s: %s",
+                                    log_id,
+                                    e,
+                                )
             _eve_file_positions[path] = f.tell()
 
         if own_session:

--- a/src/backend/tests/test_suricata_auto_incident.py
+++ b/src/backend/tests/test_suricata_auto_incident.py
@@ -1,0 +1,185 @@
+"""Tests for Suricata HIGH-severity auto-incident creation."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.suricata_ingestion import (
+    _create_security_incident,
+    _security_incident_exists,
+    _SVC_SURICATA_UUID,
+    _BFP_HQ_LONGITUDE,
+    _BFP_HQ_LATITUDE,
+    _DEFAULT_REGION_ID,
+)
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.execute.return_value.fetchone.return_value = None
+    return db
+
+
+@pytest.fixture(autouse=True)
+def _clear_positions():
+    import services.suricata_ingestion as si
+
+    si._eve_file_positions.clear()
+    yield
+
+
+class TestSecurityIncidentExists:
+    def test_returns_true_when_incident_exists(self, mock_db):
+        mock_db.execute.return_value.fetchone.return_value = (1,)
+        assert _security_incident_exists(mock_db, log_id=999) is True
+
+    def test_returns_false_when_no_incident(self, mock_db):
+        mock_db.execute.return_value.fetchone.return_value = None
+        assert _security_incident_exists(mock_db, log_id=999) is False
+
+
+class TestCreateSecurityIncident:
+    def test_high_severity_alert_creates_incident(self, mock_db):
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = (42,)
+        mock_db.execute.return_value = mock_result
+
+        incident_id = _create_security_incident(
+            mock_db,
+            log_id=1,
+            source_ip="192.168.1.100",
+            suricata_sid=123456,
+            raw_payload='{"event_type":"alert"}',
+        )
+
+        assert incident_id == 42
+        calls = mock_db.execute.call_args_list
+        fire_incident_call = calls[0]
+        params = fire_incident_call[0][1] if len(fire_incident_call[0]) > 1 else {}
+        assert params["encoder_id"] == _SVC_SURICATA_UUID
+        assert params["region_id"] == _DEFAULT_REGION_ID
+        assert params["log_id"] == 1
+
+    def test_security_incident_has_correct_location(self, mock_db):
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = (99,)
+        mock_db.execute.return_value = mock_result
+
+        _create_security_incident(
+            mock_db, log_id=5, source_ip="1.2.3.4", suricata_sid=999, raw_payload="test"
+        )
+
+        first_call_args = mock_db.execute.call_args_list[0]
+        params = first_call_args[0][1] if len(first_call_args[0]) > 1 else {}
+        assert params["lon"] == _BFP_HQ_LONGITUDE
+        assert params["lat"] == _BFP_HQ_LATITUDE
+
+    def test_security_incident_links_to_threat_log(self, mock_db):
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = (77,)
+        mock_db.execute.return_value = mock_result
+
+        _create_security_incident(
+            mock_db, log_id=55, source_ip="5.5.5.5", suricata_sid=777, raw_payload="link test"
+        )
+
+        first_call_args = mock_db.execute.call_args_list[0]
+        params = first_call_args[0][1] if len(first_call_args[0]) > 1 else {}
+        assert params["log_id"] == 55
+
+    def test_duplicate_guard_exists(self, mock_db):
+        mock_db.execute.return_value.fetchone.return_value = (1,)
+        assert _security_incident_exists(mock_db, log_id=10) is True
+
+    def test_security_incident_inserts_nonsensitive_details(self, mock_db):
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = (88,)
+        mock_db.execute.return_value = mock_result
+
+        _create_security_incident(
+            mock_db, log_id=99, source_ip="8.8.8.8", suricata_sid=999, raw_payload="payload"
+        )
+
+        calls = mock_db.execute.call_args_list
+        ns_call = calls[1]
+        ns_sql = str(ns_call[0][0])
+        ns_params = ns_call[0][1] if len(ns_call[0]) > 1 else {}
+        assert "INSERT INTO wims.incident_nonsensitive_details" in ns_sql
+        assert ns_params["iid"] == 88
+        assert ns_params["station_name"] == "Auto-detected: SID=999 SRC=8.8.8.8"
+
+    def test_security_incident_inserts_ivh_entry(self, mock_db):
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = (55,)
+        mock_db.execute.return_value = mock_result
+
+        _create_security_incident(
+            mock_db, log_id=100, source_ip="1.1.1.1", suricata_sid=111, raw_payload="ivh test"
+        )
+
+        calls = mock_db.execute.call_args_list
+        ivh_call = calls[2]
+        ivh_sql = str(ivh_call[0][0])
+        ivh_params = ivh_call[0][1] if len(ivh_call[0]) > 1 else {}
+        assert "INSERT INTO wims.incident_verification_history" in ivh_sql
+        assert ivh_params["iid"] == 55
+        assert ivh_params["uid"] == _SVC_SURICATA_UUID
+
+    def test_high_severity_triggers_auto_incident(self, mock_db):
+        import services.suricata_ingestion as si
+
+        mock_ins = MagicMock(return_value=50)
+        mock_create = MagicMock(return_value=5001)
+        mock_exists = MagicMock(return_value=False)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tf:
+            tf.write(
+                '{"event_type":"alert","src_ip":"10.0.0.1","dest_ip":"8.8.8.8","alert":{"signature_id":1,"severity":3}}\n'
+            )
+            tf.flush()
+            temp_path = tf.name
+
+        try:
+            with patch.object(si, "_insert_row", mock_ins):
+                with patch.object(si, "_security_incident_exists", mock_exists):
+                    with patch.object(si, "_create_security_incident", mock_create):
+                        si.ingest_eve_file(temp_path, db_session=mock_db)
+
+            assert mock_ins.call_count >= 1, f"_insert_row: {mock_ins.call_count}"
+            assert mock_create.call_count == 1, (
+                f"_create_security_incident: {mock_create.call_count}"
+            )
+        finally:
+            os.unlink(temp_path)
+
+    def test_medium_severity_does_not_trigger_auto_incident(self, mock_db):
+        import services.suricata_ingestion as si
+
+        mock_ins = MagicMock(return_value=50)
+        mock_create = MagicMock()
+        mock_exists = MagicMock(return_value=False)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tf:
+            tf.write(
+                '{"event_type":"alert","src_ip":"10.0.0.1","dest_ip":"8.8.8.8","alert":{"signature_id":1,"severity":2}}\n'
+            )
+            tf.flush()
+            temp_path = tf.name
+
+        try:
+            with patch.object(si, "_insert_row", mock_ins):
+                with patch.object(si, "_security_incident_exists", mock_exists):
+                    with patch.object(si, "_create_security_incident", mock_create):
+                        si.ingest_eve_file(temp_path, db_session=mock_db)
+
+            assert mock_ins.call_count >= 1, f"_insert_row: {mock_ins.call_count}"
+            assert mock_create.call_count == 0, (
+                f"_create_security_incident: {mock_create.call_count}"
+            )
+        finally:
+            os.unlink(temp_path)

--- a/src/postgres-init/34_security_incident.sql
+++ b/src/postgres-init/34_security_incident.sql
@@ -1,0 +1,21 @@
+-- 34_security_incident.sql
+-- Dependencies: 33_incident_ai_narrative.sql
+-- Idempotent: YES
+-- Issue: #68 — [M6-F] Suricata IDS Integration
+
+BEGIN;
+
+-- Add security_alert_id FK to fire_incidents
+ALTER TABLE wims.fire_incidents
+    ADD COLUMN IF NOT EXISTS security_alert_id BIGINT
+        REFERENCES wims.security_threat_logs(log_id)
+        ON DELETE SET NULL;
+
+COMMENT ON COLUMN wims.fire_incidents.security_alert_id IS
+    'FK to security_threat_logs.log_id. Non-null for auto-created security incidents.';
+
+CREATE INDEX IF NOT EXISTS idx_fire_incidents_security_alert
+    ON wims.fire_incidents (security_alert_id)
+    WHERE security_alert_id IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Closes #68 — [M6-F] Suricata IDS Integration (FRS Module 7).

HIGH severity Suricata EVE alerts now automatically create DRAFT fire 
incidents for System Admin review. MEDIUM and LOW alerts are logged to 
security_threat_logs only (existing behavior unchanged).

## Changes
- 34_security_incident.sql — security_alert_id FK on fire_incidents
- suricata_ingestion.py — _insert_row() returns log_id, auto-incident 
  creation for HIGH severity alerts with duplicate guard
- test_suricata_auto_incident.py — 10 tests, all GREEN

## Migration to apply
docker compose exec -T postgres psql -U postgres -d wims \
  < src/postgres-init/34_security_incident.sql

## Default values for security incidents
- Location: BFP HQ Manila (14.5906°N, 121.0232°E)
- Region: NCR (region_id=1)
- Status: DRAFT (requires human review)
- Category: SECURITY