### PR TITLE
fix(slice1): security hardening — JWT fallback, CORS, master key, legacy roles, hardcoded secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,19 @@ OLLAMA_URL=http://localhost:11434
 # -----------------------------------------------------------------------------
 # Firebase (required for FCM push notifications)
 # -----------------------------------------------------------------------------
-NEXT_PUBLIC_FIREBASE_API_KEY=AIzaSyArd0EsgwC1HqK51ijF1SFM4na4ABGb6Kg
-NEXT_PUBLIC_FIREBASE_VAPID_KEY=BLzOwjh0pc6cwguOw84zE6uyXmL-JnYUw6iMVsi1j7EN9jmKVNDn88TKBGjxU4SXK4n4kccxRRZB2UN0yMhXL0k
+# WARNING: Never commit real Firebase keys. The values below are placeholders.
+# For local development, create your own Firebase project and replace these.
+#
+# Required (fail-fast at startup — no default):
+NEXT_PUBLIC_FIREBASE_API_KEY=REPLACE_WITH_YOUR_FIREBASE_API_KEY
+NEXT_PUBLIC_FIREBASE_VAPID_KEY=REPLACE_WITH_YOUR_FIREBASE_VAPID_KEY
+#
+# Optional (have docker-compose.yml defaults, shown here for clarity):
+# NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+# NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-project-id
+# NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-project.firebasestorage.app
+# NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=000000000000
+# NEXT_PUBLIC_FIREBASE_APP_ID=1:000000000000:web:xxxxxxxxxxxxxxxxxxxx
 
 # -----------------------------------------------------------------------------
 # Suricata

--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,8 @@ KEYCLOAK_ADMIN_PASSWORD=admin
 # 32-byte base64-encoded key for AES-256-GCM backup encryption.
 # Generate with: openssl rand -base64 32  — NEVER commit a real key
 # Local/test key (DO NOT USE IN PRODUCTION):
-WIMS_MASTER_KEY=change-me-in-production-use-wims-generate-master-key
+# Valid 32-byte base64-encoded placeholder. Replace with a real key for production.
+WIMS_MASTER_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 
 # -----------------------------------------------------------------------------
 # AI/ML

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@
 # Database
 # -----------------------------------------------------------------------------
 DATABASE_URL=postgresql://postgres:password@localhost:5432/wims
+POSTGRES_PASSWORD=password
 
 # -----------------------------------------------------------------------------
 # Redis
@@ -20,18 +21,28 @@ REDIS_URL=redis://localhost:6379/0
 KEYCLOAK_REALM_URL=http://localhost:8080/auth/realms/bfp
 KEYCLOAK_CLIENT_ID=wims-web
 KEYCLOAK_AUDIENCE=wims-web  # Must match the client audience in the Keycloak realm (wims-web)
+KC_DB_PASSWORD=secret
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=admin
 
 # -----------------------------------------------------------------------------
 # Backup Encryption (REQUIRED for POST /api/admin/backup)
 # -----------------------------------------------------------------------------
 # 32-byte base64-encoded key for AES-256-GCM backup encryption.
 # Generate with: openssl rand -base64 32  — NEVER commit a real key
-WIMS_MASTER_KEY=REPLACE_WITH_REAL_BASE64_32BYTE_KEY
+# Local/test key (DO NOT USE IN PRODUCTION):
+WIMS_MASTER_KEY=change-me-in-production-use-wims-generate-master-key
 
 # -----------------------------------------------------------------------------
 # AI/ML
 # -----------------------------------------------------------------------------
 OLLAMA_URL=http://localhost:11434
+
+# -----------------------------------------------------------------------------
+# Firebase (required for FCM push notifications)
+# -----------------------------------------------------------------------------
+NEXT_PUBLIC_FIREBASE_API_KEY=AIzaSyArd0EsgwC1HqK51ijF1SFM4na4ABGb6Kg
+NEXT_PUBLIC_FIREBASE_VAPID_KEY=BLzOwjh0pc6cwguOw84zE6uyXmL-JnYUw6iMVsi1j7EN9jmKVNDn88TKBGjxU4SXK4n4kccxRRZB2UN0yMhXL0k
 
 # -----------------------------------------------------------------------------
 # Suricata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Create CI env file
+        working-directory: src
+        run: cp ../.env.example .env
+
       - name: Validate docker compose config
         working-directory: src
         run: |
@@ -273,6 +277,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Create CI env file
+        working-directory: src
+        run: cp ../.env.example .env
 
       - name: Bring up the stack
         working-directory: src

--- a/src/backend/api/routes/regional.py
+++ b/src/backend/api/routes/regional.py
@@ -596,7 +596,7 @@ def get_regional_incident_detail(
 ):
     """Fetch a single incident detail. Encoders see only their own; validators see any."""
     role = user.get("role", "")
-    is_validator = role in ("NATIONAL_VALIDATOR", "SYSTEM_ADMIN", "NATIONAL_ANALYST", "VALIDATOR")
+    is_validator = role in ("NATIONAL_VALIDATOR", "SYSTEM_ADMIN", "NATIONAL_ANALYST")
 
     if is_validator:
         row = db.execute(

--- a/src/backend/auth.py
+++ b/src/backend/auth.py
@@ -190,11 +190,14 @@ class KeycloakAuthenticator:
             for key_data in candidate_keys:
                 try:
                     public_key = jwk.construct(key_data)
+                    if not hasattr(public_key, "to_pem"):
+                        raise ValueError(
+                            f"JWK key {key_data.get('kid', 'unknown')} does not support PEM export"
+                        )
+                    pem_key = public_key.to_pem().decode("utf-8")
                     payload = jwt.decode(
                         token,
-                        public_key.to_pem().decode()
-                        if hasattr(public_key, "to_pem")
-                        else public_key,
+                        pem_key,
                         algorithms=["RS256"],
                         audience=AUDIENCE,
                         issuer=KEYCLOAK_ISSUER,
@@ -245,11 +248,14 @@ class KeycloakAuthenticator:
             for key_data in refreshed_keys:
                 try:
                     public_key = jwk.construct(key_data)
+                    if not hasattr(public_key, "to_pem"):
+                        raise ValueError(
+                            f"JWK key {key_data.get('kid', 'unknown')} does not support PEM export"
+                        )
+                    pem_key = public_key.to_pem().decode("utf-8")
                     payload = jwt.decode(
                         token,
-                        public_key.to_pem().decode()
-                        if hasattr(public_key, "to_pem")
-                        else public_key,
+                        pem_key,
                         algorithms=["RS256"],
                         audience=AUDIENCE,
                         issuer=KEYCLOAK_ISSUER,

--- a/src/backend/auth.py
+++ b/src/backend/auth.py
@@ -191,7 +191,7 @@ class KeycloakAuthenticator:
                 try:
                     public_key = jwk.construct(key_data)
                     if not hasattr(public_key, "to_pem"):
-                        raise ValueError(
+                        raise JWTError(
                             f"JWK key {key_data.get('kid', 'unknown')} does not support PEM export"
                         )
                     pem_key = public_key.to_pem().decode("utf-8")
@@ -249,7 +249,7 @@ class KeycloakAuthenticator:
                 try:
                     public_key = jwk.construct(key_data)
                     if not hasattr(public_key, "to_pem"):
-                        raise ValueError(
+                        raise JWTError(
                             f"JWK key {key_data.get('kid', 'unknown')} does not support PEM export"
                         )
                     pem_key = public_key.to_pem().decode("utf-8")

--- a/src/backend/tests/test_jwt_fallback.py
+++ b/src/backend/tests/test_jwt_fallback.py
@@ -81,6 +81,7 @@ def _make_constructed_key(has_pem: bool):
 def _setup_authenticator(keys, oidc_config=None):
     """Pre-populate the singleton authenticator's JWKS/oidc cache."""
     import auth as auth_module
+
     authenticator = auth_module.authenticator
     authenticator.jwks = {"keys": keys}
     authenticator.jwks_fetched_at = 9999999999.0  # far future — cached
@@ -100,12 +101,8 @@ def _setup_authenticator(keys, oidc_config=None):
 @patch("auth.jwt.decode")
 @patch("auth.jwk.construct")
 @patch("auth.jwt.get_unverified_header", return_value={"kid": "valid-key-1"})
-@patch.object(
-    __import__("auth").authenticator, "_fetch_jwks", new_callable=AsyncMock
-)
-@patch.object(
-    __import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock
-)
+@patch.object(__import__("auth").authenticator, "_fetch_jwks", new_callable=AsyncMock)
+@patch.object(__import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock)
 async def test_valid_key_with_to_pem_succeeds(
     mock_fetch_oidc,
     mock_fetch_jwks,
@@ -132,12 +129,8 @@ async def test_valid_key_with_to_pem_succeeds(
 @patch("auth.jwt.decode")
 @patch("auth.jwk.construct")
 @patch("auth.jwt.get_unverified_header", return_value={"kid": "valid-key-1"})
-@patch.object(
-    __import__("auth").authenticator, "_fetch_jwks", new_callable=AsyncMock
-)
-@patch.object(
-    __import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock
-)
+@patch.object(__import__("auth").authenticator, "_fetch_jwks", new_callable=AsyncMock)
+@patch.object(__import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock)
 async def test_key_without_to_pem_tries_next_key(
     mock_fetch_oidc,
     mock_fetch_jwks,
@@ -167,9 +160,7 @@ async def test_key_without_to_pem_tries_next_key(
 @patch("auth.jwt.decode")
 @patch("auth.jwk.construct")
 @patch("auth.jwt.get_unverified_header", return_value={"kid": "bad-only"})
-@patch.object(
-    __import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock
-)
+@patch.object(__import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock)
 async def test_no_to_pem_on_any_candidate_key_falls_back_to_refreshed_jwks(
     mock_fetch_oidc,
     mock_get_header,
@@ -180,12 +171,11 @@ async def test_no_to_pem_on_any_candidate_key_falls_back_to_refreshed_jwks(
 ):
     """All candidate keys lack to_pem — JWKS is force-refreshed and succeeds."""
     import auth as auth_module
+
     authenticator = auth_module.authenticator
 
     # Initial JWKS: one bad key
-    authenticator.jwks = {
-        "keys": [{"kid": "bad-only", "kty": "RSA", "use": "sig", "alg": "RS256"}]
-    }
+    authenticator.jwks = {"keys": [{"kid": "bad-only", "kty": "RSA", "use": "sig", "alg": "RS256"}]}
     authenticator.jwks_fetched_at = 9999999999.0
     authenticator.oidc_config = {
         "jwks_uri": "http://keycloak:8080/auth/realms/bfp/protocol/openid-connect/certs"
@@ -218,9 +208,7 @@ async def test_no_to_pem_on_any_candidate_key_falls_back_to_refreshed_jwks(
 @patch("auth.jwt.decode")
 @patch("auth.jwk.construct")
 @patch("auth.jwt.get_unverified_header", return_value={"kid": "bad-1"})
-@patch.object(
-    __import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock
-)
+@patch.object(__import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock)
 async def test_no_to_pem_on_any_key_in_both_loops_returns_401(
     mock_fetch_oidc,
     mock_get_header,
@@ -229,6 +217,7 @@ async def test_no_to_pem_on_any_key_in_both_loops_returns_401(
 ):
     """No key in either candidate or refreshed loop has to_pem → HTTP 401."""
     import auth as auth_module
+
     authenticator = auth_module.authenticator
 
     bad_keys = [{"kid": "bad-1", "kty": "RSA", "use": "sig", "alg": "RS256"}]
@@ -260,12 +249,8 @@ async def test_no_to_pem_on_any_key_in_both_loops_returns_401(
 @patch("auth.jwt.decode")
 @patch("auth.jwk.construct")
 @patch("auth.jwt.get_unverified_header", return_value={"kid": "valid-key-1"})
-@patch.object(
-    __import__("auth").authenticator, "_fetch_jwks", new_callable=AsyncMock
-)
-@patch.object(
-    __import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock
-)
+@patch.object(__import__("auth").authenticator, "_fetch_jwks", new_callable=AsyncMock)
+@patch.object(__import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock)
 async def test_jwt_decode_receives_pem_key_string(
     mock_fetch_oidc,
     mock_fetch_jwks,
@@ -294,12 +279,8 @@ async def test_jwt_decode_receives_pem_key_string(
 @patch("auth.jwt.decode")
 @patch("auth.jwk.construct")
 @patch("auth.jwt.get_unverified_header", return_value={"kid": "valid-key-1"})
-@patch.object(
-    __import__("auth").authenticator, "_fetch_jwks", new_callable=AsyncMock
-)
-@patch.object(
-    __import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock
-)
+@patch.object(__import__("auth").authenticator, "_fetch_jwks", new_callable=AsyncMock)
+@patch.object(__import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock)
 async def test_jwt_error_on_decode_failure_in_candidate_loop_tries_next(
     mock_fetch_oidc,
     mock_fetch_jwks,

--- a/src/backend/tests/test_jwt_fallback.py
+++ b/src/backend/tests/test_jwt_fallback.py
@@ -1,0 +1,329 @@
+"""
+JWT Key Fallback Unit Tests — to_pem guard + refreshed-JWKS retry
+
+Validates the explicit hasattr(to_pem) guard added in PR #213 (issue #198).
+Tests the candidate-key loop and refreshed-JWKS fallback path in
+KeycloakAuthenticator.validate_token() without requiring Docker services.
+
+Markers: unit (no Docker required — all external calls mocked)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_key_with_pem():
+    """A JWK key dict whose constructed object has to_pem()."""
+    return {"kid": "valid-key-1", "kty": "RSA", "use": "sig", "alg": "RS256"}
+
+
+@pytest.fixture
+def mock_key_no_pem():
+    """A JWK key dict whose constructed object lacks to_pem()."""
+    return {"kid": "bad-key-2", "kty": "RSA", "use": "sig", "alg": "RS256"}
+
+
+@pytest.fixture
+def mock_keys_multiple(mock_key_with_pem):
+    """Two keys: first has no to_pem, second is valid."""
+    return [
+        {"kid": "bad-key-1", "kty": "RSA", "use": "sig", "alg": "RS256"},
+        mock_key_with_pem,
+    ]
+
+
+@pytest.fixture
+def mock_valid_payload():
+    return {
+        "sub": "user-uuid-1234",
+        "exp": 2000000000,
+        "iat": 1700000000,
+        "iss": "http://localhost:8080/auth/realms/bfp/",
+        "aud": "wims-web",
+        "azp": "wims-web",
+        "preferred_username": "testuser",
+        "email": "test@example.com",
+        "realm_access": {"roles": ["REGIONAL_ENCODER"]},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# A token that looks enough like a JWT for get_unverified_header to not crash,
+# but whose real header is "eyJraWQiOiAidmFsaWQta2V5LTEifQ==" → {"kid":"valid-key-1"}
+# We override get_unverified_header in tests anyway, but providing a valid-looking
+# token avoids the "Not enough segments" JWSError on the fallback path.
+FAKE_JWT_TOKEN = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.fake-signature"
+
+
+def _make_constructed_key(has_pem: bool):
+    """Return a mock object mirroring jwk.construct() output."""
+    key = MagicMock()
+    if has_pem:
+        key.to_pem.return_value = b"fake-pem-key-bytes"
+    else:
+        del key.to_pem  # hasattr(to_pem) returns False
+    return key
+
+
+def _setup_authenticator(keys, oidc_config=None):
+    """Pre-populate the singleton authenticator's JWKS/oidc cache."""
+    import auth as auth_module
+    authenticator = auth_module.authenticator
+    authenticator.jwks = {"keys": keys}
+    authenticator.jwks_fetched_at = 9999999999.0  # far future — cached
+    authenticator.oidc_config = oidc_config or {
+        "jwks_uri": "http://keycloak:8080/auth/realms/bfp/protocol/openid-connect/certs"
+    }
+    return authenticator
+
+
+# ---------------------------------------------------------------------------
+# Tests — using @patch decorators for clean mock lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("auth.jwt.decode")
+@patch("auth.jwk.construct")
+@patch("auth.jwt.get_unverified_header", return_value={"kid": "valid-key-1"})
+@patch.object(
+    __import__("auth").authenticator, "_fetch_jwks", new_callable=AsyncMock
+)
+@patch.object(
+    __import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock
+)
+async def test_valid_key_with_to_pem_succeeds(
+    mock_fetch_oidc,
+    mock_fetch_jwks,
+    mock_get_header,
+    mock_construct,
+    mock_decode,
+    mock_key_with_pem,
+    mock_valid_payload,
+):
+    """Candidate key has to_pem() — token decodes and returns payload."""
+    authenticator = _setup_authenticator([mock_key_with_pem])
+    mock_construct.return_value = _make_constructed_key(True)
+    mock_decode.return_value = mock_valid_payload
+
+    result = await authenticator.validate_token(FAKE_JWT_TOKEN)
+
+    assert result["sub"] == mock_valid_payload["sub"]
+    assert result["azp"] == "wims-web"
+    mock_construct.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("auth.jwt.decode")
+@patch("auth.jwk.construct")
+@patch("auth.jwt.get_unverified_header", return_value={"kid": "valid-key-1"})
+@patch.object(
+    __import__("auth").authenticator, "_fetch_jwks", new_callable=AsyncMock
+)
+@patch.object(
+    __import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock
+)
+async def test_key_without_to_pem_tries_next_key(
+    mock_fetch_oidc,
+    mock_fetch_jwks,
+    mock_get_header,
+    mock_construct,
+    mock_decode,
+    mock_keys_multiple,
+    mock_valid_payload,
+):
+    """First key lacks to_pem() — loop continues to second key which has it."""
+    authenticator = _setup_authenticator(mock_keys_multiple)
+    # First key: no to_pem; second key: has to_pem
+    mock_construct.side_effect = [
+        _make_constructed_key(False),
+        _make_constructed_key(True),
+    ]
+    mock_decode.return_value = mock_valid_payload
+
+    result = await authenticator.validate_token(FAKE_JWT_TOKEN)
+
+    assert result["sub"] == mock_valid_payload["sub"]
+    assert mock_construct.call_count == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("auth.jwt.decode")
+@patch("auth.jwk.construct")
+@patch("auth.jwt.get_unverified_header", return_value={"kid": "bad-only"})
+@patch.object(
+    __import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock
+)
+async def test_no_to_pem_on_any_candidate_key_falls_back_to_refreshed_jwks(
+    mock_fetch_oidc,
+    mock_get_header,
+    mock_construct,
+    mock_decode,
+    mock_key_with_pem,
+    mock_valid_payload,
+):
+    """All candidate keys lack to_pem — JWKS is force-refreshed and succeeds."""
+    import auth as auth_module
+    authenticator = auth_module.authenticator
+
+    # Initial JWKS: one bad key
+    authenticator.jwks = {
+        "keys": [{"kid": "bad-only", "kty": "RSA", "use": "sig", "alg": "RS256"}]
+    }
+    authenticator.jwks_fetched_at = 9999999999.0
+    authenticator.oidc_config = {
+        "jwks_uri": "http://keycloak:8080/auth/realms/bfp/protocol/openid-connect/certs"
+    }
+
+    # _fetch_jwks with force_refresh=True replaces keys with good one
+    async def fetch_jwks_fresh(force_refresh=False):
+        if force_refresh:
+            authenticator.jwks = {"keys": [mock_key_with_pem]}
+
+    fetch_jwks_mock = AsyncMock(side_effect=fetch_jwks_fresh)
+    with patch.object(authenticator, "_fetch_jwks", new=fetch_jwks_mock):
+        # First key: no to_pem (candidate loop fails)
+        # Second key: has to_pem (refreshed loop succeeds)
+        mock_construct.side_effect = [
+            _make_constructed_key(False),
+            _make_constructed_key(True),
+        ]
+        mock_decode.return_value = mock_valid_payload
+
+        result = await authenticator.validate_token(FAKE_JWT_TOKEN)
+
+        assert result["sub"] == mock_valid_payload["sub"]
+        assert mock_construct.call_count == 2
+        fetch_jwks_mock.assert_any_call(force_refresh=True)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("auth.jwt.decode")
+@patch("auth.jwk.construct")
+@patch("auth.jwt.get_unverified_header", return_value={"kid": "bad-1"})
+@patch.object(
+    __import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock
+)
+async def test_no_to_pem_on_any_key_in_both_loops_returns_401(
+    mock_fetch_oidc,
+    mock_get_header,
+    mock_construct,
+    mock_decode,
+):
+    """No key in either candidate or refreshed loop has to_pem → HTTP 401."""
+    import auth as auth_module
+    authenticator = auth_module.authenticator
+
+    bad_keys = [{"kid": "bad-1", "kty": "RSA", "use": "sig", "alg": "RS256"}]
+    authenticator.jwks = {"keys": bad_keys}
+    authenticator.jwks_fetched_at = 9999999999.0
+    authenticator.oidc_config = {
+        "jwks_uri": "http://keycloak:8080/auth/realms/bfp/protocol/openid-connect/certs"
+    }
+
+    async def fetch_jwks_still_bad(force_refresh=False):
+        if force_refresh:
+            authenticator.jwks = {"keys": bad_keys}  # still no to_pem
+
+    fetch_jwks_mock = AsyncMock(side_effect=fetch_jwks_still_bad)
+    with patch.object(authenticator, "_fetch_jwks", new=fetch_jwks_mock):
+        mock_construct.side_effect = [
+            _make_constructed_key(False),
+            _make_constructed_key(False),
+        ]
+
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticator.validate_token(FAKE_JWT_TOKEN)
+        assert exc_info.value.status_code == 401
+        assert "JWT validation failed" in exc_info.value.detail
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("auth.jwt.decode")
+@patch("auth.jwk.construct")
+@patch("auth.jwt.get_unverified_header", return_value={"kid": "valid-key-1"})
+@patch.object(
+    __import__("auth").authenticator, "_fetch_jwks", new_callable=AsyncMock
+)
+@patch.object(
+    __import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock
+)
+async def test_jwt_decode_receives_pem_key_string(
+    mock_fetch_oidc,
+    mock_fetch_jwks,
+    mock_get_header,
+    mock_construct,
+    mock_decode,
+    mock_key_with_pem,
+    mock_valid_payload,
+):
+    """Prove jwt.decode() receives the PEM-decoded string from to_pem().decode('utf-8')."""
+    authenticator = _setup_authenticator([mock_key_with_pem])
+    mock_construct.return_value = _make_constructed_key(True)
+    mock_decode.return_value = mock_valid_payload
+
+    await authenticator.validate_token(FAKE_JWT_TOKEN)
+
+    # jwt.decode should have been called with the pem string as second positional arg
+    call_args = mock_decode.call_args
+    pem_arg = call_args[0][1]  # second positional arg is the key
+    assert isinstance(pem_arg, str)
+    assert pem_arg == "fake-pem-key-bytes"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("auth.jwt.decode")
+@patch("auth.jwk.construct")
+@patch("auth.jwt.get_unverified_header", return_value={"kid": "valid-key-1"})
+@patch.object(
+    __import__("auth").authenticator, "_fetch_jwks", new_callable=AsyncMock
+)
+@patch.object(
+    __import__("auth").authenticator, "_fetch_oidc_config", new_callable=AsyncMock
+)
+async def test_jwt_error_on_decode_failure_in_candidate_loop_tries_next(
+    mock_fetch_oidc,
+    mock_fetch_jwks,
+    mock_get_header,
+    mock_construct,
+    mock_decode,
+    mock_keys_multiple,
+    mock_valid_payload,
+):
+    """First key decodes OK but jwt.decode raises JWTError → second key succeeds."""
+    from jose import JWTError
+
+    authenticator = _setup_authenticator(mock_keys_multiple)
+    # Both keys have to_pem; first jwt.decode raises JWTError, second succeeds
+    mock_construct.side_effect = [
+        _make_constructed_key(True),
+        _make_constructed_key(True),
+    ]
+    mock_decode.side_effect = [
+        JWTError("Signature verification failed"),
+        mock_valid_payload,
+    ]
+
+    result = await authenticator.validate_token(FAKE_JWT_TOKEN)
+    assert result["sub"] == mock_valid_payload["sub"]
+    assert mock_construct.call_count == 2
+    assert mock_decode.call_count == 2

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -124,7 +124,7 @@ services:
     build: ./backend
     container_name: wims-backend
     environment:
-      - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/wims
+      - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD:?error}@postgres:5432/wims
       - PYTHONPATH=/app
       - REDIS_URL=redis://redis:6379/0
       - KEYCLOAK_REALM_URL=http://keycloak:8080/auth/realms/bfp
@@ -163,7 +163,7 @@ services:
     container_name: wims-celery-worker
     command: celery -A main.celery_app worker --beat --loglevel=info
     environment:
-      - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/wims
+      - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD:?error}@postgres:5432/wims
       - REDIS_URL=redis://redis:6379/0
       - KEYCLOAK_REALM_URL=http://keycloak:8080/auth/realms/bfp
       - OLLAMA_URL=http://ollama:11434

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     container_name: wims-postgres
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?error}
       POSTGRES_DB: wims
     volumes:
       - postgres_data:/var/lib/postgresql/data
@@ -61,9 +61,9 @@ services:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
       KC_DB_USERNAME: keycloak
-      KC_DB_PASSWORD: secret
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_DB_PASSWORD: ${KC_DB_PASSWORD:?error}
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:?error}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?error}
       KC_HTTP_RELATIVE_PATH: /auth
       KC_PROXY: edge
       KC_PROXY_HEADERS: xforwarded
@@ -96,8 +96,8 @@ services:
       - ./keycloak/bootstrap:/opt/keycloak/bootstrap:ro
     environment:
       KEYCLOAK_URL: http://keycloak:8080/auth
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:?error}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?error}
     networks:
       - wims_internal
     depends_on:
@@ -124,7 +124,7 @@ services:
     build: ./backend
     container_name: wims-backend
     environment:
-      - DATABASE_URL=postgresql://postgres:password@postgres:5432/wims
+      - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/wims
       - PYTHONPATH=/app
       - REDIS_URL=redis://redis:6379/0
       - KEYCLOAK_REALM_URL=http://keycloak:8080/auth/realms/bfp
@@ -133,8 +133,8 @@ services:
       - KEYCLOAK_AUDIENCE=wims-web
       - KEYCLOAK_ADMIN_CLIENT_ID=${KEYCLOAK_ADMIN_CLIENT_ID:-}
       - KEYCLOAK_ADMIN_CLIENT_SECRET=${KEYCLOAK_ADMIN_CLIENT_SECRET:-}
-      - KEYCLOAK_ADMIN_USER=admin
-      - KEYCLOAK_ADMIN_PASSWORD=admin
+      - KEYCLOAK_ADMIN_USER=${KEYCLOAK_ADMIN:?error}
+      - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD:?error}
       - OLLAMA_URL=http://ollama:11434
       - AFOR_TEMPLATE_PATH=/app/AFOR-FORMATTED.xlsx
       - CSRF_TRUSTED_ORIGINS=http://localhost,https://localhost,http://127.0.0.1,http://127.0.0.1:3000
@@ -163,7 +163,7 @@ services:
     container_name: wims-celery-worker
     command: celery -A main.celery_app worker --beat --loglevel=info
     environment:
-      - DATABASE_URL=postgresql://postgres:password@postgres:5432/wims
+      - DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/wims
       - REDIS_URL=redis://redis:6379/0
       - KEYCLOAK_REALM_URL=http://keycloak:8080/auth/realms/bfp
       - OLLAMA_URL=http://ollama:11434
@@ -192,13 +192,13 @@ services:
         NEXT_PUBLIC_BASE_URL: http://localhost
         NEXT_PUBLIC_OIDC_REDIRECT_URI: http://localhost/callback
         NEXT_PUBLIC_OIDC_AUTHORITY: /auth/realms/bfp
-        NEXT_PUBLIC_FIREBASE_API_KEY: AIzaSyArd0EsgwC1HqK51ijF1SFM4na4ABGb6Kg
-        NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: wims-bfp.firebaseapp.com
-        NEXT_PUBLIC_FIREBASE_PROJECT_ID: wims-bfp
-        NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: wims-bfp.firebasestorage.app
-        NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: "465171995576"
-        NEXT_PUBLIC_FIREBASE_APP_ID: "1:465171995576:web:9aa2403d8f6b9c4bb50d4d"
-        NEXT_PUBLIC_FIREBASE_VAPID_KEY: BLzOwjh0pc6cwguOw84zE6uyXmL-JnYUw6iMVsi1j7EN9jmKVNDn88TKBGjxU4SXK4n4kccxRRZB2UN0yMhXL0k
+        NEXT_PUBLIC_FIREBASE_API_KEY: ${NEXT_PUBLIC_FIREBASE_API_KEY:?error}
+        NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN:-wims-bfp.firebaseapp.com}
+        NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${NEXT_PUBLIC_FIREBASE_PROJECT_ID:-wims-bfp}
+        NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET:-wims-bfp.firebasestorage.app}
+        NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID:-465171995576}
+        NEXT_PUBLIC_FIREBASE_APP_ID: ${NEXT_PUBLIC_FIREBASE_APP_ID:-1:465171995576:web:9aa2403d8f6b9c4bb50d4d}
+        NEXT_PUBLIC_FIREBASE_VAPID_KEY: ${NEXT_PUBLIC_FIREBASE_VAPID_KEY:?error}
     container_name: wims-frontend
     environment:
       - NEXT_PUBLIC_API_URL=/api
@@ -209,13 +209,13 @@ services:
       - NEXT_PUBLIC_OIDC_CLIENT_ID=wims-web
       - NEXT_PUBLIC_APP_URL=http://localhost
       - BACKEND_URL=http://backend:8000
-      - NEXT_PUBLIC_FIREBASE_API_KEY=AIzaSyArd0EsgwC1HqK51ijF1SFM4na4ABGb6Kg
-      - NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=wims-bfp.firebaseapp.com
-      - NEXT_PUBLIC_FIREBASE_PROJECT_ID=wims-bfp
-      - NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=wims-bfp.firebasestorage.app
-      - NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=465171995576
-      - NEXT_PUBLIC_FIREBASE_APP_ID=1:465171995576:web:9aa2403d8f6b9c4bb50d4d
-      - NEXT_PUBLIC_FIREBASE_VAPID_KEY=BLzOwjh0pc6cwguOw84zE6uyXmL-JnYUw6iMVsi1j7EN9jmKVNDn88TKBGjxU4SXK4n4kccxRRZB2UN0yMhXL0k
+      - NEXT_PUBLIC_FIREBASE_API_KEY=${NEXT_PUBLIC_FIREBASE_API_KEY:?error}
+      - NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=${NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN:-wims-bfp.firebaseapp.com}
+      - NEXT_PUBLIC_FIREBASE_PROJECT_ID=${NEXT_PUBLIC_FIREBASE_PROJECT_ID:-wims-bfp}
+      - NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=${NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET:-wims-bfp.firebasestorage.app}
+      - NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=${NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID:-465171995576}
+      - NEXT_PUBLIC_FIREBASE_APP_ID=${NEXT_PUBLIC_FIREBASE_APP_ID:-1:465171995576:web:9aa2403d8f6b9c4bb50d4d}
+      - NEXT_PUBLIC_FIREBASE_VAPID_KEY=${NEXT_PUBLIC_FIREBASE_VAPID_KEY:?error}
     networks:
       - wims_internal
     depends_on:

--- a/src/keycloak/import/bfp-realm.json
+++ b/src/keycloak/import/bfp-realm.json
@@ -101,22 +101,8 @@
         "containerId": "0d7644e4-1107-4da2-83f4-ca7ac87ce39b"
       },
       {
-        "name": "VALIDATOR",
-        "description": "VALIDATOR role for WIMS-BFP",
-        "composite": false,
-        "clientRole": false,
-        "containerId": "0d7644e4-1107-4da2-83f4-ca7ac87ce39b"
-      },
-      {
         "name": "NATIONAL_VALIDATOR",
         "description": "NATIONAL_VALIDATOR role for WIMS-BFP",
-        "composite": false,
-        "clientRole": false,
-        "containerId": "0d7644e4-1107-4da2-83f4-ca7ac87ce39b"
-      },
-      {
-        "name": "ANALYST",
-        "description": "ANALYST role for WIMS-BFP",
         "composite": false,
         "clientRole": false,
         "containerId": "0d7644e4-1107-4da2-83f4-ca7ac87ce39b"

--- a/src/nginx/nginx.conf
+++ b/src/nginx/nginx.conf
@@ -6,6 +6,13 @@ http {
     server_tokens off;
     proxy_hide_header X-Powered-By;
 
+    # Restrict CORS to known production origins — never echo $http_origin
+    map $http_origin $cors_origin {
+        default "";
+        "https://wimsbfp.tech" $http_origin;
+        "https://wims.bfp.gov.ph" $http_origin;
+    }
+
     upstream backend_servers {
         server backend:8000;
         keepalive 32;
@@ -90,16 +97,15 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             # Keep cookie Domain in sync between nginx-gateway and browser
             proxy_cookie_domain nginx-gateway $host;
-            # CORS headers — same-origin only (CSRF mitigation). The backend does not
-            # add CORS headers, so nginx provides them for same-origin SPA requests.
-            add_header Access-Control-Allow-Origin $scheme://$host always;
+            # CORS headers — backend does not add them, so nginx provides them.
+            add_header Access-Control-Allow-Origin $cors_origin always;
             add_header Access-Control-Allow-Credentials true always;
             add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE, OPTIONS' always;
             add_header Access-Control-Allow-Headers 'Authorization, Content-Type, Cookie' always;
 
             # Handle OPTIONS preflight directly — do not proxy to backend.
             if ($request_method = 'OPTIONS') {
-                add_header Access-Control-Allow-Origin $scheme://$host always;
+                add_header Access-Control-Allow-Origin $cors_origin always;
                 add_header Access-Control-Allow-Credentials true always;
                 add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE, OPTIONS' always;
                 add_header Access-Control-Allow-Headers 'Authorization, Content-Type, Cookie' always;

--- a/system-wiki/architecture/infrastructure-config.md
+++ b/system-wiki/architecture/infrastructure-config.md
@@ -4,7 +4,7 @@ created: 2026-05-16
 updated: 2026-06-05
 type: architecture
 tags: [wims-bfp, docker, nginx, suricata, keycloak, infrastructure]
-sources: [src/docker-compose.yml, src/docker-compose.prod.yml, src/.env.production.example, src/nginx/, src/suricata/, src/keycloak/bfp-realm.json]
+sources: [src/docker-compose.yml, src/docker-compose.prod.yml, src/.env.production.example, src/nginx/, src/suricata/, src/keycloak/import/bfp-realm.json, .github/workflows/ci.yml]
 status: draft
 ---
 
@@ -38,6 +38,8 @@ status: draft
 
 **Named volumes:** `postgres_data`, `ollama_data`, `incident_attachments_data`
 
+**Required env interpolation:** Base `src/docker-compose.yml` intentionally uses `${VAR:?error}` for local/test secrets such as `POSTGRES_PASSWORD`, `KC_DB_PASSWORD`, `KEYCLOAK_ADMIN`, `KEYCLOAK_ADMIN_PASSWORD`, `NEXT_PUBLIC_FIREBASE_API_KEY`, and `NEXT_PUBLIC_FIREBASE_VAPID_KEY`. GitHub CI jobs that run compose (`docker-build`, `security-scan`) copy root `.env.example` to `src/.env` before `docker compose config`, build, or stack startup so fail-fast interpolation remains enabled without committing real secrets.
+
 **Host port exposure:** Only `nginx-gateway` intentionally binds public interfaces (`0.0.0.0:80` and `0.0.0.0:443`). Database and support/admin surfaces are bound to host loopback only: Postgres `127.0.0.1:5432`, Redis `127.0.0.1:6379`, MailHog `127.0.0.1:1025`/`8025`, and direct Keycloak `127.0.0.1:8080`. Browser and OIDC traffic should reach Keycloak only through nginx at `/auth/`.
 
 **Host firewall:** UFW is enabled on the VPS with default deny incoming, allow outgoing, and explicit inbound allows only for SSH `22/tcp`, HTTP `80/tcp`, and HTTPS `443/tcp` on IPv4/IPv6.
@@ -46,13 +48,13 @@ status: draft
 
 | Variable | Default |
 |---|---|
-| `DATABASE_URL` | `postgresql://postgres:password@postgres:5432/wims` |
+| `DATABASE_URL` | `postgresql://postgres:${POSTGRES_PASSWORD:?error}@postgres:5432/wims` in compose; production may override through environment |
 | `REDIS_URL` | `redis://redis:6379/0` |
 | `KEYCLOAK_REALM_URL` | `http://keycloak:8080/auth/realms/bfp` |
 | `KEYCLOAK_ISSUER` | `${PUBLIC_BASE_URL}/auth/realms/bfp` in production override; current VPS `PUBLIC_BASE_URL=https://wimsbfp.tech` |
 | `KEYCLOAK_CLIENT_ID` | `wims-web` |
-| `KEYCLOAK_ADMIN_USER` | `admin` |
-| `KEYCLOAK_ADMIN_PASSWORD` | `admin` |
+| `KEYCLOAK_ADMIN_USER` | `${KEYCLOAK_ADMIN:?error}` |
+| `KEYCLOAK_ADMIN_PASSWORD` | `${KEYCLOAK_ADMIN_PASSWORD:?error}` |
 | `OLLAMA_URL` | `http://ollama:11434` |
 | `SURICATA_EVE_PATH` | `/var/log/suricata/eve.json` |
 | `EXPORT_DIR` | `/app/storage/exports` |
@@ -114,7 +116,7 @@ Use explicit `-f` flags on the VPS. Plain `docker compose up` auto-loads `docker
 **Key config points:**
 - `client_max_body_size 50M`
 - OPTIONS preflight handled directly by nginx (returns 204), not proxied to backend
-- CORS: dynamic `Access-Control-Allow-Origin: $http_origin`
+- CORS: production uses a deny-by-default `$cors_origin` map for `Access-Control-Allow-Origin` with explicit HTTPS origins; local dev remains same-origin via `$scheme://$host`
 - Cookie domain rewrite: `proxy_cookie_domain nginx-gateway $host` — rewrites backend's `Domain=nginx-gateway` to the request host so the browser accepts it
 - TLS terminates in nginx on port 443 for `wimsbfp.tech` using `/etc/letsencrypt/live/wimsbfp.tech/fullchain.pem` and `privkey.pem`
 - Gateway security headers: nginx disables version tokens, hides proxied `X-Powered-By`, and adds HSTS, `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: no-referrer`, and a restrictive camera/microphone permissions policy while allowing same-origin geolocation.
@@ -141,7 +143,7 @@ Use explicit `-f` flags on the VPS. Plain `docker compose up` auto-loads `docker
 
 ## Keycloak Realm
 
-**File:** `src/keycloak/bfp-realm.json` (~2641 lines)
+**File:** `src/keycloak/import/bfp-realm.json` (~2641 lines)
 
 Full Keycloak realm export for the `bfp` realm.
 

--- a/system-wiki/architecture/infrastructure-config.md
+++ b/system-wiki/architecture/infrastructure-config.md
@@ -1,7 +1,7 @@
 ---
 title: Infrastructure Configuration
 created: 2026-05-16
-updated: 2026-06-03
+updated: 2026-06-05
 type: architecture
 tags: [wims-bfp, docker, nginx, suricata, keycloak, infrastructure]
 sources: [src/docker-compose.yml, src/docker-compose.prod.yml, src/.env.production.example, src/nginx/, src/suricata/, src/keycloak/bfp-realm.json]
@@ -200,8 +200,8 @@ MailHog local development: host=`mailhog`, port=`1025`, from=`noreply@wims-bfp.l
 | `NATIONAL_VALIDATOR` | National validator |
 | `NATIONAL_ANALYST` | National analyst |
 | `SYSTEM_ADMIN` | System administrator |
-| `VALIDATOR` | Legacy validator alias |
-| `ANALYST` | Legacy analyst alias |
+
+> **Note (2026-06-05, PR #213):** Legacy roles `VALIDATOR` and `ANALYST` were removed from `bfp-realm.json` in issue #206. Only the four canonical roles above remain.
 
 ### Clients
 

--- a/system-wiki/architecture/pwa-tests-cicd.md
+++ b/system-wiki/architecture/pwa-tests-cicd.md
@@ -1,7 +1,7 @@
 ---
 title: PWA/Offline-First, Tests & CI/CD
 created: 2026-05-16
-updated: 2026-06-04
+updated: 2026-06-05
 type: architecture
 tags: [wims-bfp, pwa, offline-first, testing, ci-cd, service-worker]
 sources: [src/frontend/src/lib/, src/frontend/public/sw.js, .github/workflows/, src/backend/main.py, src/backend/tests/test_immutable_records.py]
@@ -167,8 +167,8 @@ Uses `unittest.mock` (MagicMock, patch), `tmp_path`, `monkeypatch`. No database 
 | `migrations` | ubuntu-latest | PostGIS 15-3.4 service container, applies all .sql files in lexical order, asserts schema |
 | `frontend` | ubuntu-latest | Node 20, `npm ci` → `npm run lint` → `npx vitest run` → `npm run build` |
 | `backend` | ubuntu-latest | Python 3.12, PostGIS + Redis 7 service containers. `KEYCLOAK_CLIENT_ID`/`KEYCLOAK_AUDIENCE` are set to `wims-web`/`wims-web`; Direct Grant tests scope `bfp-client` separately. `ruff check` → `ruff format --check` → `pytest -v --tb=short` (8 test files excluded) |
-| `docker-build` | ubuntu-latest | `docker compose config` validation + `docker compose build --parallel` |
-| `security-scan` | ubuntu-latest | OWASP ZAP baseline scan + Nmap port scan. Uses `.zap/rules.tsv` to ignore 7 pre-existing WARN alerts (CSP/COEP headers, Keycloak upstream, Next.js informational). Uses `zaproxy/action-baseline@v0.15.0` plus explicit artifact name `zap-scan` to avoid legacy artifact-upload rejection in older ZAP action packaging. `fail_action: true` — only new HIGH/CRITICAL block merge. Stack is brought up with `docker compose -f docker-compose.yml -f docker-compose.ci.yml` to use the HTTP-only `nginx.ci.conf`, avoiding TLS certificate requirements that exist in the local (`nginx.local.conf`) and production (`nginx.conf`) configs. |
+| `docker-build` | ubuntu-latest | Copies root `.env.example` to `src/.env` for required compose interpolation, then runs `docker compose config` validation + `docker compose build --parallel` |
+| `security-scan` | ubuntu-latest | Copies root `.env.example` to `src/.env`, then runs OWASP ZAP baseline scan + Nmap port scan. Uses `.zap/rules.tsv` to ignore 7 pre-existing WARN alerts (CSP/COEP headers, Keycloak upstream, Next.js informational). Uses `zaproxy/action-baseline@v0.15.0` plus explicit artifact name `zap-scan` to avoid legacy artifact-upload rejection in older ZAP action packaging. `fail_action: true` — only new HIGH/CRITICAL block merge. Stack is brought up with `docker compose -f docker-compose.yml -f docker-compose.ci.yml` to use the HTTP-only `nginx.ci.conf`, avoiding TLS certificate requirements that exist in the local (`nginx.local.conf`) and production (`nginx.conf`) configs. |
 | `merge-gate` | ubuntu-latest | **Blocks merge** unless migrations, frontend, backend, docker-build, and security-scan all pass |
 
 ### CD — `.github/workflows/cd.yml`

--- a/system-wiki/gaps/frs-codebase-gap-register.md
+++ b/system-wiki/gaps/frs-codebase-gap-register.md
@@ -1,7 +1,7 @@
 ---
 title: FRS Codebase Gap Register
 created: 2026-05-14
-updated: 2026-05-30
+updated: 2026-06-05
 type: gap
 tags: [wims-bfp, gap, frs, needs-verification]
 sources: [raw/frs, raw/codebase/codebase-snapshot-2026-05-14.md]
@@ -37,7 +37,8 @@ This register prevents agents from hallucinating completion. A module is not com
 - **M9 (System Monitoring)**: PARTIAL → M9a CLOSED — PR #103 backend monitoring endpoints; **PR #125 M9a** completes dashboard UI (CPU/RAM/disk + workers, grouped 60s refresh). Full-text log search still open.
 - **#194 (Keycloak audience default)**: CLOSED — `.env.example` `KEYCLOAK_AUDIENCE` changed from `account` → `wims-web`.
 - **#195 (Redis connection pooling)**: CLOSED — `event_bus.py` sync pool + async pool; `public_dmz.py` async pool (max_connections=20). No behavioral change.
-- **#205 (Env master key placeholder)**: CLOSED — `.env.example` `WIMS_MASTER_KEY` replaced with `REPLACE_WITH_REAL_BASE64_32BYTE_KEY` placeholder + generation comment.
+- **#205 (Env master key placeholder)**: CLOSED — `.env.example` `WIMS_MASTER_KEY` replaced with valid base64 all-zeros placeholder (`AAAA...=`) plus `openssl rand -base64 32` generation instructions and "DO NOT USE IN PRODUCTION" warning (PR #213).
+- **#206 (Legacy Keycloak roles removed)**: CLOSED — `VALIDATOR` and `ANALYST` roles removed from `src/keycloak/import/bfp-realm.json`; canonical roles (`NATIONAL_VALIDATOR`, `NATIONAL_ANALYST`, `REGIONAL_ENCODER`, `SYSTEM_ADMIN`) preserved. Stale `"VALIDATOR"` reference in `regional.py:599` also cleaned up (PR #213 follow-up).
 - **M4 (Incident Workflow)**: CLOSED — PR #102: AFOR import fixes, field persistence, validator audit trail, VALIDATOR role routing, immutable rule fix.
 - **M8d (HITL Structured Decision Audit Log)**: CLOSED — `39_hitl_decision.sql` adds `hitl_decision JSONB` to `security_threat_logs`; `PATCH /admin/security-logs/{log_id}` accepts structured `{ action, note }` with three-button HITL UI (Confirm Threat / False Positive / Request More Info); decision logged as JSONB with `reviewed_by` and `reviewed_at`; `resolved_at` set only on terminal decisions (CONFIRM_THREAT, FALSE_POSITIVE); `REQUEST_MORE_INFO` leaves `resolved_at` null.
 - **M2b (Offline Encryption — AES-256-GCM)**: CLOSED — `offlineStore.ts` encrypts IndexedDB queue items with AES-256-GCM via Web Crypto API; per-user key stored in `crypto-keys` IndexedDB store, derived from user secret via PBKDF2; transparent encrypt on `addToQueue`/`updateQueuedIncident`, transparent decrypt on `getQueuedIncident`; `markSynced` operates on raw record (no payload read needed); closes ISSUE#139.

--- a/system-wiki/index.md
+++ b/system-wiki/index.md
@@ -1,8 +1,8 @@
 # WIMS-BFP System Wiki Index
 
-Last updated: 2026-06-04
+Last updated: 2026-06-05
 Total synthesis pages: 32
-Last changes: PR #207 review fixes added current-password step-up for self-service email/login-identity changes, RLS-backed profile contact lookup, local unique email index documentation, and frontend partial-update handling.
+Last changes: PR #213 follow-ups documented fail-fast compose env handling in CI, production CORS `$cors_origin` behavior, canonical Keycloak roles, Firebase env placeholders, and JWT fallback test coverage.
 Purpose: project-local knowledgebase for agents routing themselves to relevant WIMS-BFP context.
 
 ## Start Here

--- a/system-wiki/log.md
+++ b/system-wiki/log.md
@@ -3,6 +3,21 @@
 Chronological record of system-wiki changes. Append-only.
 Format: `## [YYYY-MM-DD] action | subject`
 
+## [2026-06-05] fix | PR #213 review follow-ups — stale role, Firebase env, JWT tests, wiki sync
+
+**PR #213 three-axis review follow-ups applied (worktree: pr-213):**
+
+- **Stale `"VALIDATOR"` removed from `regional.py:599`:** Replaced `("NATIONAL_VALIDATOR", "SYSTEM_ADMIN", "NATIONAL_ANALYST", "VALIDATOR")` with just the three canonical roles. Legacy `VALIDATOR` role was removed from `bfp-realm.json` in #206; this code reference was missed.
+- **`.env.example` Firebase section hardened:** Replaced committed real Firebase API key and VAPID key with `REPLACE_WITH_YOUR_...` placeholders. Documented all 7 Firebase env vars (2 required with `:?error`, 5 optional with `:-default`). Added warning comment.
+- **JWT `to_pem` fallback unit tests:** Added `tests/test_jwt_fallback.py` with 6 unit tests covering: valid key with `to_pem`, key without `to_pem` tries next, all-candidate-keys-fail force-refreshes JWKS, no-to_pem-on-any-key returns 401, `jwt.decode` receives PEM string, and JWTError in candidate loop tries next key. All use `@pytest.mark.unit` and mock authenticator internals — no Docker required.
+- **Nginx CORS: DELETE preserved intentionally.** The PR body claimed DELETE was removed from CORS methods but it was not (and should not be) — backend has DELETE endpoints (`DELETE /api/regional/incidents/{id}`, draft management). The `$cors_origin` map deny-by-default is the actual CORS hardening.
+- **Wiki sync:**
+  - `system-wiki/security/security-baseline.md`: Updated stale `$scheme://$host` CORS line to describe production `$cors_origin` map.
+  - `system-wiki/architecture/infrastructure-config.md`: Removed legacy `VALIDATOR`/`ANALYST` from Roles table; added note about #206 removal.
+  - `system-wiki/gaps/frs-codebase-gap-register.md`: Updated #205 entry to reference current `AAAA...=` placeholder; added #206 closure entry.
+
+**Files changed:** `regional.py`, `.env.example`, `test_jwt_fallback.py` (new), `security-baseline.md`, `infrastructure-config.md`, `frs-codebase-gap-register.md`, `log.md`
+
 ## [2026-06-03] fix | PR #212 review fixes — Redis pool bounding, thread-safety, test hygiene
 
 - **Redis connection pool:** Added `max_connections=10` to `_get_redis()` in `civilian.py`, matching `map.py`'s bounded-pool pattern. Prevents unbounded connection growth under load.

--- a/system-wiki/log.md
+++ b/system-wiki/log.md
@@ -3,6 +3,12 @@
 Chronological record of system-wiki changes. Append-only.
 Format: `## [YYYY-MM-DD] action | subject`
 
+## [2026-06-05] fix | PR #213 CI follow-up — compose env setup and backend format gate
+
+- **CI compose env setup:** `.github/workflows/ci.yml` now copies root `.env.example` to `src/.env` before `docker-build` compose validation/build and before `security-scan` stack startup. This preserves `${VAR:?error}` fail-fast behavior in `src/docker-compose.yml` while giving ephemeral CI the required local/test values.
+- **Backend format gate:** `src/backend/tests/test_jwt_fallback.py` was formatted with `ruff format` so the backend CI `ruff format --check .` step can pass.
+- **Wiki sync:** `system-wiki/architecture/pwa-tests-cicd.md` documents the CI env-file pre-step; `system-wiki/architecture/infrastructure-config.md` documents required compose interpolation, CI handling, updated backend env values, authoritative Keycloak import path, and production CORS map behavior; `system-wiki/index.md` updated its last-change summary.
+
 ## [2026-06-05] fix | PR #213 review follow-ups — stale role, Firebase env, JWT tests, wiki sync
 
 **PR #213 three-axis review follow-ups applied (worktree: pr-213):**

--- a/system-wiki/security/security-baseline.md
+++ b/system-wiki/security/security-baseline.md
@@ -1,7 +1,7 @@
 ---
 title: Security Baseline
 created: 2026-05-14
-updated: 2026-06-04
+updated: 2026-06-05
 type: security
 tags: [wims-bfp, security, auth, rbac, rls, audit-log, ids, xai, privacy, fail-closed]
 sources: [raw/frs/frs-auth.md, raw/frs/frs-complianceanddataprivacy.md, raw/frs/frs-intrusiondetectionandnetworkingmonitoring.md, raw/frs/frs-threatdetectionwithexplainableai.md, raw/codebase/codebase-snapshot-2026-05-14.md]
@@ -53,7 +53,7 @@ FRS Module 11b requires Cross-Site Request Forgery testing. The following layers
 - **SameSite=Strict cookies:** Auth cookies (`__Host-access_token`, `__Host-refresh_token`) are set with `Secure; HttpOnly; SameSite=Strict; Path=/`. No `Domain` attribute. Implemented in `src/frontend/src/app/api/auth/sync/route.ts`, `refresh/route.ts`, and `logout/route.ts`.
 - **`__Host-` cookie prefix:** Prevents subdomain cookie injection — compliant browsers reject `__Host-` cookies set from any context that does not match the origin exactness requirements (HTTPS, no Domain, Path=/).
 - **Origin/Referer validation middleware:** `src/backend/utils/csrf.py` — `csrf_middleware` is registered on the FastAPI app via `app.middleware("http")`. GET/HEAD/OPTIONS bypass (safe methods). POST/PUT/PATCH/DELETE without a valid Origin or Referer matching the configured allowlist are rejected with 403. Allowlist from `CSRF_TRUSTED_ORIGINS` env var, falling back to localhost defaults. **Exemption:** the zero-trust public DMZ path prefix `/api/v1/public/` is explicitly excluded from CSRF validation because these endpoints are unauthenticated (no Keycloak JWT, no cookie dependency) and are protected by rate limiting + Pydantic validation instead.
-- **Nginx CORS restricted:** `Access-Control-Allow-Origin` set to `$scheme://$host` (not `$http_origin` reflection) in both production and local nginx configs.
+- **Nginx CORS restricted:** Production `Access-Control-Allow-Origin` uses a deny-by-default `$cors_origin` map (whitelisted origins: `https://wimsbfp.tech`, `https://wims.bfp.gov.ph`). Local dev config uses `$scheme://$host`. Neither echoes `$http_origin`.
 - **Pen-test checklist:** `docs/pentest/CSRF-CHECKLIST.md` documents all manual verification procedures.
 - **Test coverage:** `src/backend/tests/test_csrf_middleware.py` covers safe methods, invalid/missing Origin, valid Origin, Referer fallback, PUT/PATCH/DELETE variants, and VPS production origin scenarios.
 


### PR DESCRIPTION
## Slice 1 — Security Hardening

Five fixes from the three-axis review backlog:

### #198 — Fix latent JWT key fallback bug
Removed unsafe `else public_key` dict fallback in `auth.py`. Both JWT decode sites now require explicit `to_pem()` conversion and raise `JWTError` if PEM export is unavailable. Added focused unit tests for the candidate-key and refreshed-JWKS retry paths.

### #199 — Restrict CORS origins in nginx
Production nginx now restricts `Access-Control-Allow-Origin` to known origins (`https://wimsbfp.tech`, `https://wims.bfp.gov.ph`) via a deny-by-default `$cors_origin` map. Allowed methods remain unchanged because DELETE is still required by draft-management API endpoints; CSRF protection and origin allowlisting provide the hardening.

### #205 — Remove real AES-256-GCM master key from .env.example
Replaced the committed real key with a valid local/test base64 placeholder plus generation instructions and an explicit production warning.

### #206 — Remove legacy Keycloak realm roles
Removed `VALIDATOR` and `ANALYST` from the authoritative Keycloak realm import (`src/keycloak/import/bfp-realm.json`) and cleaned up the remaining stale `VALIDATOR` role check in `regional.py`.

### #192 — Remove hardcoded secrets from docker-compose.yml
Hardcoded passwords were replaced with `${VAR:?error}` fail-fast references. `.env.example` now provides dev defaults/placeholders and documents all Firebase public client env vars without committing real project keys.

### Documentation and validation
- Updated system-wiki security/infrastructure/gap pages and log for the CORS, role, env, and placeholder changes.
- Validated with targeted JWT tests, regional lifecycle tests, ruff checks, conflict-marker search, and `docker compose config --quiet` with temporary env values.

Closes #198, closes #199, closes #205, closes #206, closes #192
