### PR TITLE
fix(slice2): infra & config — pin images, nginx local dev, audience fix, rate limit PKCE callback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ REDIS_URL=redis://localhost:6379/0
 # Keycloak
 # -----------------------------------------------------------------------------
 KEYCLOAK_REALM_URL=http://localhost:8080/auth/realms/bfp
-KEYCLOAK_CLIENT_ID=bfp-client
+KEYCLOAK_CLIENT_ID=wims-web
 KEYCLOAK_AUDIENCE=wims-web  # Must match the client audience in the Keycloak realm (wims-web)
 
 # -----------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,8 +223,8 @@ jobs:
         run: pytest -v --tb=short --ignore=tests/test_rate_limiting.py --ignore=tests/test_suricata_ingestion.py --ignore=tests/test_infra_config.py --ignore=tests/integration/test_wims_initial_schema_bootstrap.py --ignore=tests/integration/test_auth_otp_policy.py --ignore=tests/integration/test_database_schema.py --ignore=tests/integration/test_rls_policy_enforcement.py --ignore=tests/integration/test_sql_quality_audit.py
         env:
           KEYCLOAK_REALM_URL: "http://localhost:8080/auth/realms/bfp"
-          KEYCLOAK_CLIENT_ID: "bfp-client"
-          KEYCLOAK_AUDIENCE: "account"
+          KEYCLOAK_CLIENT_ID: "wims-web"
+          KEYCLOAK_AUDIENCE: "wims-web"
           DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/wims_test"
           REDIS_URL: "redis://localhost:6379/0"
           WIMS_MASTER_KEY: ${{ secrets.WIMS_MASTER_KEY }}
@@ -233,8 +233,8 @@ jobs:
         run: pytest --cov=. --cov-report=term-missing --cov-fail-under=30 --ignore=tests/test_rate_limiting.py --ignore=tests/test_suricata_ingestion.py --ignore=tests/test_infra_config.py --ignore=tests/integration/test_wims_initial_schema_bootstrap.py --ignore=tests/integration/test_auth_otp_policy.py --ignore=tests/integration/test_database_schema.py --ignore=tests/integration/test_rls_policy_enforcement.py --ignore=tests/integration/test_sql_quality_audit.py
         env:
           KEYCLOAK_REALM_URL: "http://localhost:8080/auth/realms/bfp"
-          KEYCLOAK_CLIENT_ID: "bfp-client"
-          KEYCLOAK_AUDIENCE: "account"
+          KEYCLOAK_CLIENT_ID: "wims-web"
+          KEYCLOAK_AUDIENCE: "wims-web"
           DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/wims_test"
           REDIS_URL: "redis://localhost:6379/0"
           WIMS_MASTER_KEY: ${{ secrets.WIMS_MASTER_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,8 @@ jobs:
       NEXT_PUBLIC_AUTH_API_URL: ${{ vars.NEXT_PUBLIC_AUTH_API_URL }}
       NEXT_PUBLIC_BASE_URL: ${{ vars.NEXT_PUBLIC_BASE_URL }}
       KEYCLOAK_REALM_URL: "http://localhost:8080/auth/realms/bfp"
-      KEYCLOAK_CLIENT_ID: "bfp-client"
-      KEYCLOAK_AUDIENCE: "account"
+      KEYCLOAK_CLIENT_ID: "wims-web"
+      KEYCLOAK_AUDIENCE: "wims-web"
       DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/wims_test"
       REDIS_URL: "redis://localhost:6379/0"
       WIMS_MASTER_KEY: ${{ secrets.WIMS_MASTER_KEY }}
@@ -104,8 +104,8 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       REDIS_URL: ${{ secrets.REDIS_URL }}
       KEYCLOAK_REALM_URL: ${{ secrets.KEYCLOAK_REALM_URL }}
-      KEYCLOAK_CLIENT_ID: ${{ secrets.KEYCLOAK_CLIENT_ID }}
-      KEYCLOAK_AUDIENCE: ${{ secrets.KEYCLOAK_AUDIENCE }}
+      KEYCLOAK_CLIENT_ID: "wims-web"
+      KEYCLOAK_AUDIENCE: "wims-web"
       WIMS_MASTER_KEY: ${{ secrets.WIMS_MASTER_KEY }}
       FIREBASE_CREDENTIALS_PATH: ${{ secrets.FIREBASE_CREDENTIALS_PATH }}
       KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD }}

--- a/docs/API_AND_FUNCTIONS.md
+++ b/docs/API_AND_FUNCTIONS.md
@@ -8,8 +8,8 @@ Source of truth: `src/backend/main.py` and `src/backend/api/routes/*.py`
 
 | Method | Path | Auth | Purpose |
 |---|---|---|---|
-| POST | `/api/auth/login` | Public | Stub login endpoint; guarded by Redis sliding-window middleware. |
-| POST | `/api/auth/callback` | Public | Exchanges PKCE code with Keycloak and upserts user in `wims.users`. |
+| POST | `/api/auth/login` | Public | Stub login endpoint; always returns 401. |
+| POST | `/api/auth/callback` | Public | Exchanges PKCE code with Keycloak, upserts user in `wims.users`, and is guarded by Redis sliding-window rate limiting. |
 | GET | `/api/user/me` | JWT (`get_current_user`) | Returns merged token + user profile payload; provisions user on first access if needed. |
 | POST | `/api/auth/verify-session` | Public | Validates a pre-obtained access token and enforces concurrent session limits. Used by Next.js sync route. |
 
@@ -122,5 +122,5 @@ Source: `src/frontend/src/app/`
 | Method | Path | Purpose |
 |---|---|---|
 | GET | `/api/auth/session` | Resolves current user session by forwarding cookie to backend `/api/user/me`. |
-| POST | `/api/auth/sync` | Sets HttpOnly `access_token` cookie; also supports code exchange forwarding to backend callback. |
+| POST | `/api/auth/sync` | Sets HttpOnly `access_token` cookie; also supports code exchange forwarding to backend callback with trusted proxy client-IP headers for backend rate limiting. |
 | POST | `/api/auth/logout` | Clears auth cookies (`access_token`, `refresh_token`). |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,7 +65,7 @@ This aligns with glossary terms: civilian intake, validator-centered verificatio
 
 ## Security-Relevant Mechanics
 
-- Login rate limiting is implemented in backend middleware for `POST /api/auth/login` using a Redis Lua sliding-window script.
+- Auth-flow rate limiting is implemented in backend middleware for `POST /api/auth/callback` using a Redis Lua sliding-window script; the user-facing Next.js `/api/auth/sync` route forwards trusted proxy client-IP headers before calling the backend callback.
 - Suricata logs are mounted into worker-accessible paths and ingested by task modules.
 - No hard-delete admin endpoint is defined in admin route modules; updates are mutation-oriented (user/log state updates and audit readout).
 - PII fields (`caller_name`, `caller_number`, `owner_name`, `street_address`) are encrypted at rest using AES-256-GCM via `utils/crypto.py`. Plaintext PII columns are always `NULL` for new writes.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -130,7 +130,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   - `GET/PATCH /api/admin/users` — user management (SYSTEM_ADMIN)
   - `GET/PATCH/POST /api/admin/security-logs` — threat log management with AI analysis
   - `GET /api/admin/audit-logs` — paginated audit trail
-  - Rate-limiting middleware on `POST /api/auth/login` (Redis sliding window)
+  - Rate-limiting middleware on the auth callback flow (now `POST /api/auth/callback`, Redis sliding window)
 - **Supabase Edge Functions:** `analytics-summary`, `commit-incident`, `conflict-detection`, `security-event-action`, `upload-bundle`
 - **Frontend pages:** Dashboard, incidents list/create/import/triage, incident detail with conflict detection, public report form, admin system hub, operations center (`/home`)
 - **Database schema:** `wims` schema with PostGIS geography columns, soft-delete support, chain-of-custody audit trails, geographic reference tables (regions/provinces/cities/barangays)

--- a/src/backend/api/routes/admin.py
+++ b/src/backend/api/routes/admin.py
@@ -81,6 +81,8 @@ def _apply_backup_retention() -> None:
             continue
 
 
+# Legacy admin/API tier label retained for compatibility. The historical
+# "login" tier now represents the auth callback flow guarded by main.py.
 RATE_LIMIT_CONFIG_KEY = "rate_limit_config:login"
 RATE_LIMIT_DEFAULTS = {"window_seconds": 900, "threshold": 5}
 
@@ -1156,7 +1158,7 @@ async def restore_backup(
 def get_rate_limits(
     current_user: dict = Depends(get_system_admin),
 ):
-    """Return current rate limit config for all tiers."""
+    """Return auth-flow rate limit config using the legacy ``login`` tier label."""
     r = redis.from_url(os.getenv("REDIS_URL", "redis://redis:6379/0"), decode_responses=True)
     try:
         config = r.hgetall(RATE_LIMIT_CONFIG_KEY)
@@ -1183,7 +1185,7 @@ def update_rate_limits(
     current_user: dict = Depends(get_system_admin),
     db: Session = Depends(get_db_with_rls),
 ):
-    """Update rate limit config for a tier. Takes effect immediately without restart."""
+    """Update rate limit config for the legacy ``login`` auth-flow tier."""
     config_key = f"rate_limit_config:{body.tier}"
     updated_at = str(time.time())
 

--- a/src/backend/api/routes/public_dmz.py
+++ b/src/backend/api/routes/public_dmz.py
@@ -25,7 +25,7 @@ router = APIRouter(prefix="/api/v1/public", tags=["public-dmz"])
 
 
 # ---------------------------------------------------------------------------
-# Redis Rate Limiter — 3 req/IP/hour (strictly tighter than /api/auth/login)
+# Redis Rate Limiter — 3 req/IP/hour (stricter than the auth callback limiter)
 # ---------------------------------------------------------------------------
 _PUBLIC_RATE_LIMIT_WINDOW = 3600  # 1 hour in seconds
 _PUBLIC_RATE_LIMIT_THRESHOLD = 3  # max 3 submissions per IP per hour

--- a/src/backend/api/routes/user.py
+++ b/src/backend/api/routes/user.py
@@ -183,7 +183,9 @@ def change_my_password(
     """
     Change the current user's own password.
     The current password is verified against Keycloak before allowing the change.
-    Uses bfp-client (public, DAG-enabled) — the same client the browser uses to authenticate.
+    Uses bfp-client (public, Direct Grant-enabled), retained separately from the
+    browser PKCE client (wims-web) because password verification requires the
+    Resource Owner Password Credentials grant.
     """
     keycloak_id = current_user["keycloak_id"]
 
@@ -195,8 +197,9 @@ def change_my_password(
     except Exception:
         target_username = current_user.get("kc_username") or current_user["username"]
 
-    # Verify current password using bfp-client (public, directAccessGrantsEnabled=true)
-    # This matches exactly how the browser authenticates the user
+    # Verify current password using bfp-client (public, directAccessGrantsEnabled=true).
+    # Do not replace with KEYCLOAK_CLIENT_ID/wims-web: the web client uses PKCE,
+    # while this server-side verification path needs Direct Grant.
     kc_openid = KeycloakOpenID(
         server_url=_KC_BASE_URL,
         realm_name=_KC_REALM,

--- a/src/backend/auth.py
+++ b/src/backend/auth.py
@@ -23,10 +23,10 @@ KEYCLOAK_REALM_URL = os.environ.get(
     os.environ.get("KEYCLOAK_URL", "http://localhost:8080/auth/realms/bfp"),
 )
 KEYCLOAK_URL = os.environ.get("NEXT_PUBLIC_AUTH_API_URL", KEYCLOAK_REALM_URL)
-CLIENT_ID = os.environ.get("KEYCLOAK_CLIENT_ID", "bfp-client")
+CLIENT_ID = os.environ.get("KEYCLOAK_CLIENT_ID", "wims-web")
 # audience is what Keycloak puts in the token's "aud" claim — must match CLIENT_ID.
 # If KEYCLOAK_AUDIENCE is unset, default to the CLIENT_ID so they stay in sync.
-AUDIENCE = os.environ.get("KEYCLOAK_AUDIENCE", os.environ.get("KEYCLOAK_CLIENT_ID", "bfp-client"))
+AUDIENCE = os.environ.get("KEYCLOAK_AUDIENCE", os.environ.get("KEYCLOAK_CLIENT_ID", "wims-web"))
 JWKS_CACHE_TTL_SECONDS = (
     60  # 60 seconds — Keycloak key rotation typically hourly/daily; balance freshness vs latency
 )

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -205,8 +205,8 @@ RATE_LIMIT_THRESHOLD = 5
 @app.middleware("http")
 async def rate_limit_middleware(request: Request, call_next):
     """Sliding-window rate limiter applied before every request."""
-    # Only rate-limit the login endpoint
-    if request.url.path != "/api/auth/login" or request.method != "POST":
+    # Rate-limit the PKCE callback endpoint (real auth flow)
+    if request.url.path != "/api/auth/callback" or request.method != "POST":
         return await call_next(request)
 
     r = await _get_redis()

--- a/src/backend/tests/integration/test_keycloak_password_reset.py
+++ b/src/backend/tests/integration/test_keycloak_password_reset.py
@@ -47,7 +47,10 @@ KEYCLOAK_ADMIN_URL = os.environ.get("KEYCLOAK_ADMIN_URL", "http://localhost:8080
 KEYCLOAK_ADMIN_USER = os.environ.get("KEYCLOAK_ADMIN_USER", "admin")
 KEYCLOAK_ADMIN_PASSWORD = os.environ.get("KEYCLOAK_ADMIN_PASSWORD", "admin")
 KEYCLOAK_REALM = os.environ.get("KEYCLOAK_REALM", "bfp")
-KEYCLOAK_CLIENT_ID = os.environ.get("KEYCLOAK_CLIENT_ID", "bfp-client")
+# Password-reset verification uses a Direct Grant-enabled client. Keep this
+# scoped to the password-reset tests instead of reusing the web OIDC
+# KEYCLOAK_CLIENT_ID, which defaults to the PKCE-only wims-web client.
+KEYCLOAK_CLIENT_ID = os.environ.get("KEYCLOAK_PASSWORD_RESET_CLIENT_ID", "bfp-client")
 
 MAILHOG_API_URL = os.environ.get("MAILHOG_API_URL", "http://localhost:8025")
 
@@ -348,7 +351,7 @@ class TestForgotPasswordConfiguration:
         When resetPasswordAllowed=true, the login page must contain
         a 'Forgot Password?' link pointing to the reset-credentials flow.
         """
-        # Fetch the login page for the bfp-client
+        # Fetch the login page for the Direct Grant password-reset client
         r = httpx.get(
             f"{REALM_URL}/protocol/openid-connect/auth",
             params={

--- a/src/backend/tests/test_dynamic_rate_limits.py
+++ b/src/backend/tests/test_dynamic_rate_limits.py
@@ -4,6 +4,8 @@ Task: Dynamic Rate Limit Configuration — #47.
 Red State: GET/PATCH /api/admin/rate-limits endpoints do not exist.
 Green State: GET returns current config, PATCH updates it.
 Config is stored in Redis hash key rate_limit_config:{tier}.
+The legacy tier label is "login" for API compatibility; it represents the
+current auth callback rate-limit policy.
 """
 
 import pytest

--- a/src/backend/tests/test_rate_limiting.py
+++ b/src/backend/tests/test_rate_limiting.py
@@ -1,18 +1,22 @@
 """
-Task 3: Rate Limiting & Throttling — RED STATE
+Task 3: Rate Limiting & Throttling — manual adversarial check
 
-Objective: Prove that /api/auth/login is vulnerable to a 10-request burst
-from a single client IP with ZERO throttling.
+Objective: prove that the real protected auth flow, POST /api/auth/callback,
+rejects a burst above the configured threshold from one client IP.
 
 Adversarial Assertions:
-  - Requests 1–5  → HTTP 401 (invalid credentials, no rate limit)
+  - Requests 1–5  → processed by the callback flow and fail for invalid PKCE data
   - Requests 6–10 → HTTP 429 (rate limiter MUST engage)
   - Every 429 response MUST include a Retry-After header
 
-Since no rate limiter exists, this test MUST FAIL.
+This live-stack test is intentionally excluded from CI because it depends on a
+reachable backend, Redis, and auth callback plumbing. Set
+RATE_LIMIT_TEST_BASE_URL if the backend is exposed somewhere other than
+http://localhost:8000.
 """
 
 import asyncio
+import os
 
 import httpx
 import pytest
@@ -20,18 +24,18 @@ import pytest
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-# The Next.js dev server runs on port 3000 by default.
-# Adjust BASE_URL if the app is served elsewhere.
-BASE_URL = "http://localhost:3000"
-LOGIN_ENDPOINT = f"{BASE_URL}/api/auth/login"
+# Directly target the backend callback path protected by main.py middleware.
+BASE_URL = os.environ.get("RATE_LIMIT_TEST_BASE_URL", "http://localhost:8000")
+AUTH_CALLBACK_ENDPOINT = f"{BASE_URL.rstrip('/')}/api/auth/callback"
 
-MOCK_IP = "192.168.1.1"
+MOCK_IP = os.environ.get("RATE_LIMIT_TEST_IP", "192.168.1.1")
 
-# Deliberately invalid credentials — we don't need a valid session,
-# we need the server to accept but reject the auth attempt.
+# Deliberately invalid PKCE callback data: the requests should reach the
+# callback and fail token exchange unless/until the rate limiter blocks them.
 PAYLOAD = {
-    "username": "adversarial_tester@bfp.gov.ph",
-    "password": "TotallyWrongPassword!42",
+    "code": "adversarial_fake_code",
+    "code_verifier": "adversarial_fake_verifier",
+    "redirect_uri": "http://localhost/callback",
 }
 
 BURST_SIZE = 10
@@ -42,10 +46,10 @@ RATE_LIMIT_THRESHOLD = 5  # First N requests are allowed through
 # Helpers
 # ---------------------------------------------------------------------------
 async def _fire_burst(client: httpx.AsyncClient) -> list[httpx.Response]:
-    """Send BURST_SIZE rapid POST requests to the login endpoint."""
+    """Send BURST_SIZE rapid POST requests to the auth callback endpoint."""
     tasks = [
         client.post(
-            LOGIN_ENDPOINT,
+            AUTH_CALLBACK_ENDPOINT,
             json=PAYLOAD,
             headers={"X-Forwarded-For": MOCK_IP},
         )
@@ -58,14 +62,14 @@ async def _fire_burst(client: httpx.AsyncClient) -> list[httpx.Response]:
 # Tests
 # ---------------------------------------------------------------------------
 class TestRateLimiting:
-    """Adversarial test suite for login endpoint rate limiting."""
+    """Adversarial test suite for auth callback rate limiting."""
 
     @pytest.mark.asyncio
     async def test_burst_returns_429_after_threshold(self):
         """
-        Fire 10 concurrent requests from a single IP.
-        The first 5 MUST be processed normally (401 for bad creds).
-        Requests 6–10 MUST be rejected with HTTP 429.
+        Fire 10 concurrent callback requests from a single IP.
+        At most the first 5 may reach callback processing; the remainder MUST
+        be rejected with HTTP 429.
         """
         async with httpx.AsyncClient() as client:
             responses = await _fire_burst(client)
@@ -78,7 +82,7 @@ class TestRateLimiting:
         # --- Assertion 1: At most RATE_LIMIT_THRESHOLD requests go through
         assert len(allowed) <= RATE_LIMIT_THRESHOLD, (
             f"Expected at most {RATE_LIMIT_THRESHOLD} non-429 responses, "
-            f"got {len(allowed)}.  The endpoint has NO rate limiter."
+            f"got {len(allowed)}.  The callback path is not rate-limited."
         )
 
         # --- Assertion 2: The remainder MUST be 429
@@ -101,7 +105,8 @@ class TestRateLimiting:
 
         # If there are no 429s at all, the rate limiter is missing — fail hard.
         assert len(throttled) > 0, (
-            "No HTTP 429 responses received.  The endpoint is completely unthrottled."
+            "No HTTP 429 responses received.  The callback endpoint is completely "
+            "unthrottled."
         )
 
         for i, resp in enumerate(throttled):
@@ -117,20 +122,22 @@ class TestRateLimiting:
             )
 
     @pytest.mark.asyncio
-    async def test_allowed_requests_return_401(self):
+    async def test_allowed_requests_fail_auth_flow_not_success(self):
         """
-        Requests that slip under the rate limit with invalid credentials
-        MUST return HTTP 401 Unauthorized — not 200, not 500.
+        Requests that slip under the rate limit use invalid PKCE data and MUST
+        fail auth processing rather than creating a session.
         """
         async with httpx.AsyncClient() as client:
             responses = await _fire_burst(client)
 
         allowed = [r for r in responses if r.status_code != 429]
 
-        assert len(allowed) > 0, "Zero non-429 responses — cannot verify auth rejection behaviour."
+        assert len(allowed) > 0, (
+            "Zero non-429 responses — cannot verify auth rejection behaviour."
+        )
 
         for i, resp in enumerate(allowed):
-            assert resp.status_code == 401, (
+            assert resp.status_code >= 400, (
                 f"Non-throttled request #{i + 1} returned HTTP {resp.status_code}, "
-                f"expected 401 Unauthorized."
+                "expected auth callback failure for invalid PKCE data."
             )

--- a/src/backend/tests/test_rate_limiting.py
+++ b/src/backend/tests/test_rate_limiting.py
@@ -105,8 +105,7 @@ class TestRateLimiting:
 
         # If there are no 429s at all, the rate limiter is missing — fail hard.
         assert len(throttled) > 0, (
-            "No HTTP 429 responses received.  The callback endpoint is completely "
-            "unthrottled."
+            "No HTTP 429 responses received.  The callback endpoint is completely unthrottled."
         )
 
         for i, resp in enumerate(throttled):
@@ -132,9 +131,7 @@ class TestRateLimiting:
 
         allowed = [r for r in responses if r.status_code != 429]
 
-        assert len(allowed) > 0, (
-            "Zero non-429 responses — cannot verify auth rejection behaviour."
-        )
+        assert len(allowed) > 0, "Zero non-429 responses — cannot verify auth rejection behaviour."
 
         for i, resp in enumerate(allowed):
             assert resp.status_code >= 400, (

--- a/src/docker-compose.prod.yml
+++ b/src/docker-compose.prod.yml
@@ -24,8 +24,8 @@ services:
       - NEXT_PUBLIC_APP_URL=${PUBLIC_BASE_URL}
       - BACKEND_URL=http://backend:8000
 
-  # Production TLS certs — not available in local dev (override swaps nginx.conf)
+  # Production TLS certs — not available in local dev (override swaps nginx.conf).
+  # nginx.conf mount is in the base compose file; this file only adds production certs.
   nginx-gateway:
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ${LETSENCRYPT_DIR:-/opt/wims-bfp/letsencrypt}:/etc/letsencrypt:ro

--- a/src/docker-compose.prod.yml
+++ b/src/docker-compose.prod.yml
@@ -23,3 +23,9 @@ services:
       - NEXT_PUBLIC_OIDC_AUTHORITY=${PUBLIC_BASE_URL}/auth/realms/bfp
       - NEXT_PUBLIC_APP_URL=${PUBLIC_BASE_URL}
       - BACKEND_URL=http://backend:8000
+
+  # Production TLS certs — not available in local dev (override swaps nginx.conf)
+  nginx-gateway:
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ${LETSENCRYPT_DIR:-/opt/wims-bfp/letsencrypt}:/etc/letsencrypt:ro

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -235,7 +235,7 @@ services:
 
   # --- Edge Gateway ---
   nginx-gateway:
-    image: nginx:alpine
+    image: nginx:1.27.3-alpine
     container_name: wims-nginx-gateway
     ports:
       - "80:80"

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -106,7 +106,7 @@ services:
     restart: "no"
 
   ollama:
-    image: ollama/ollama:latest
+    image: ollama/ollama:0.5.1
     container_name: wims-ollama
     volumes:
       - ollama_data:/root/.ollama
@@ -221,7 +221,7 @@ services:
       - backend
 
   wims-suricata:
-    image: jasonish/suricata:latest
+    image: jasonish/suricata:7.0.5
     container_name: wims-suricata
     restart: unless-stopped
     # In a real production environment, you use network_mode: "host"
@@ -242,7 +242,7 @@ services:
       - "443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ${LETSENCRYPT_DIR:-/opt/wims-bfp/letsencrypt}:/etc/letsencrypt:ro
+      # TLS certificates are production-only — mount via docker-compose.prod.yml or deployment override
     networks:
       - wims_internal
     depends_on:

--- a/src/frontend/src/app/api/auth/sync/route.ts
+++ b/src/frontend/src/app/api/auth/sync/route.ts
@@ -10,6 +10,23 @@ function backendUrl(path: string): string {
   return `${BACKEND_URL.replace(/\/$/, '')}${path}`;
 }
 
+function trustedClientIp(req: NextRequest): string | null {
+  const realIp = req.headers.get('x-real-ip')?.trim();
+  if (realIp) {
+    return realIp;
+  }
+
+  const forwardedFor = req.headers.get('x-forwarded-for');
+  if (!forwardedFor) {
+    return null;
+  }
+
+  // Nginx appends the immediate remote address to X-Forwarded-For. Forward only
+  // that trusted hop instead of relaying a client-supplied chain that the
+  // backend rate limiter would treat as authoritative.
+  return forwardedFor.split(',').pop()?.trim() || null;
+}
+
 const ACCESS_TOKEN_COOKIE_MAX_AGE = 5 * 60; // 5 minutes: match Keycloak accessTokenLifespan
 const REFRESH_TOKEN_COOKIE_MAX_AGE = 8 * 60 * 60; // 8 hours: match SSO session max
 
@@ -49,9 +66,18 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const callbackHeaders: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    const clientIp = trustedClientIp(req);
+    if (clientIp) {
+      callbackHeaders['X-Real-IP'] = clientIp;
+      callbackHeaders['X-Forwarded-For'] = clientIp;
+    }
+
     const res = await fetch(backendUrl('/api/auth/callback'), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: callbackHeaders,
       body: JSON.stringify({ code, code_verifier, redirect_uri }),
     });
 

--- a/system-wiki/architecture/infrastructure-config.md
+++ b/system-wiki/architecture/infrastructure-config.md
@@ -1,7 +1,7 @@
 ---
 title: Infrastructure Configuration
 created: 2026-05-16
-updated: 2026-05-30
+updated: 2026-06-03
 type: architecture
 tags: [wims-bfp, docker, nginx, suricata, keycloak, infrastructure]
 sources: [src/docker-compose.yml, src/docker-compose.prod.yml, src/.env.production.example, src/nginx/, src/suricata/, src/keycloak/bfp-realm.json]
@@ -31,8 +31,8 @@ status: draft
 | keycloak-bootstrap | wims-keycloak-bootstrap | `quay.io/keycloak/keycloak:24.0.0` | (one-shot, no ports) |
 | backend | wims-backend | Dockerfile at `./backend/Dockerfile` (python:3.11-slim) | 8000 (internal) |
 | frontend | wims-frontend | `./frontend/Dockerfile` (Next.js) | 3000 (internal) |
-| wims-suricata | wims-suricata | `jasonish/suricata:latest` | (none) |
-| nginx-gateway | wims-nginx-gateway | `nginx:alpine` | 80, 443 |
+| wims-suricata | wims-suricata | `jasonish/suricata:7.0.5` | (none) |
+| nginx-gateway | wims-nginx-gateway | `nginx:1.27.3-alpine` | 80, 443 |
 
 **Health checks:** postgres (`pg_isready -U postgres -d wims`, interval 5s), redis (`redis-cli ping`, interval 5s). Backend depends on both service_healthy.
 
@@ -96,9 +96,9 @@ Use explicit `-f` flags on the VPS. Plain `docker compose up` auto-loads `docker
 
 **Current certificate state:** `src/nginx/nginx.conf` expects `/etc/letsencrypt/live/wimsbfp.tech/fullchain.pem` and `privkey.pem`. A Let’s Encrypt certificate for `wimsbfp.tech` was issued on the VPS on 2026-05-26 and certbot renewal is installed with an nginx reload hook.
 
-**TLS mount:** `src/docker-compose.yml` parameterizes the certificate bind as `${LETSENCRYPT_DIR:-/opt/wims-bfp/letsencrypt}:/etc/letsencrypt:ro`. On the VPS, `src/.env.production` sets `LETSENCRYPT_DIR=/etc/letsencrypt`, so `wims-nginx-gateway` receives the host certificate tree directly. Do not replace this with a repo-local symlink directory; Docker bind mounts expose the directory itself, so mounting `/opt/wims-bfp/letsencrypt` when it only contains `letsencrypt -> /etc/letsencrypt` hides the expected `/etc/letsencrypt/live/<domain>/...` paths from nginx.
+**TLS mount:** `src/docker-compose.yml` no longer mounts certificate paths in the dev-neutral base service. Production TLS is added only by `src/docker-compose.prod.yml`, which binds `${LETSENCRYPT_DIR:-/opt/wims-bfp/letsencrypt}:/etc/letsencrypt:ro` for `wims-nginx-gateway`. On the VPS, `src/.env.production` sets `LETSENCRYPT_DIR=/etc/letsencrypt`, so the gateway receives the host certificate tree directly. Do not replace this with a repo-local symlink directory; Docker bind mounts expose the directory itself, so mounting `/opt/wims-bfp/letsencrypt` when it only contains `letsencrypt -> /etc/letsencrypt` hides the expected `/etc/letsencrypt/live/<domain>/...` paths from nginx.
 
-**Frontend/auth env:** `docker-compose.prod.yml` sets browser-facing frontend build/runtime variables to the public HTTPS origin (`${PUBLIC_BASE_URL}`) or relative paths (`/api`, `/auth`). The development compose file also uses relative `/api` and `/auth` for browser-facing access, so local HTTPS desk checks stay same-origin and avoid CORS preflight redirects from `https://localhost` to `http://localhost/api`. The Next.js server-side auth routes use `BACKEND_URL=http://backend:8000` in both development and production, and route handlers append `/api/...` explicitly. Keycloak advertises `KC_HOSTNAME_URL=${PUBLIC_BASE_URL}/auth` in production to keep OIDC discovery issuer/endpoints aligned with the nginx `/auth/` proxy path.
+**Frontend/auth env:** `docker-compose.prod.yml` sets browser-facing frontend build/runtime variables to the public HTTPS origin (`${PUBLIC_BASE_URL}`) or relative paths (`/api`, `/auth`). The development compose file also uses relative `/api` and `/auth` for browser-facing access, so local HTTP desk checks stay same-origin and avoid CORS preflight redirects. The Next.js server-side auth routes use `BACKEND_URL=http://backend:8000` in both development and production, and route handlers append `/api/...` explicitly. Keycloak advertises `KC_HOSTNAME_URL=${PUBLIC_BASE_URL}/auth` in production to keep OIDC discovery issuer/endpoints aligned with the nginx `/auth/` proxy path. For `POST /api/auth/sync`, the route forwards nginx-provided `X-Real-IP`/sanitized `X-Forwarded-For` to backend `POST /api/auth/callback` so backend Redis rate limiting keys by end-user IP rather than by the frontend container.
 
 **Route Table:**
 
@@ -127,7 +127,7 @@ Use explicit `-f` flags on the VPS. Plain `docker compose up` auto-loads `docker
 
 ## Suricata IDS
 
-**Container:** `jasonish/suricata:latest` with `-i eth0`
+**Container:** `jasonish/suricata:7.0.5` with `-i eth0`
 
 **Directories:**
 - `src/suricata/logs/` → `/var/log/suricata/` — EVE JSON output, fast.log, stats.log

--- a/system-wiki/architecture/pwa-tests-cicd.md
+++ b/system-wiki/architecture/pwa-tests-cicd.md
@@ -142,7 +142,7 @@ Unique static analysis pattern. Uses `inspect.getsource()` to capture route func
 Uses `unittest.mock` (MagicMock, patch), `tmp_path`, `monkeypatch`. No database needed. Tests: column allowlist filtering, Celery task dispatch, argument deduplication, role rejection, file I/O verification with `csv.DictReader`.
 
 **3. Integration Tests (`test_keycloak_password_reset.py`)**
-~750 lines, full e2e against live services. Patterns: fixture-based prerequisites (auto-skip if Keycloak unreachable), resource setup/teardown, helper functions for API interaction, MailHog email extraction. Tests pre-flight config (5) + full e2e flow (4) including OWASP user enumeration prevention, single-use token enforcement.
+~750 lines, full e2e against live services. Patterns: fixture-based prerequisites (auto-skip if Keycloak unreachable), resource setup/teardown, helper functions for API interaction, MailHog email extraction. Tests pre-flight config (5) + full e2e flow (4) including OWASP user enumeration prevention, single-use token enforcement. The test uses `KEYCLOAK_PASSWORD_RESET_CLIENT_ID` (default `bfp-client`) for Direct Grant-specific checks so CI/global backend auth defaults can remain `wims-web`/`wims-web`.
 
 **4. ci.yml exclusions** — 8 test files explicitly excluded from CI runner: rate-limiting, suricata, infra-config, bootstrap, OTP, schema, RLS policy, SQL quality (need special Docker setup).
 
@@ -163,7 +163,7 @@ Uses `unittest.mock` (MagicMock, patch), `tmp_path`, `monkeypatch`. No database 
 | `security-audit` | ubuntu-latest | `pip-audit` + `npm audit --omit=dev` (continue-on-error) |
 | `migrations` | ubuntu-latest | PostGIS 15-3.4 service container, applies all .sql files in lexical order, asserts schema |
 | `frontend` | ubuntu-latest | Node 20, `npm ci` → `npm run lint` → `npx vitest run` → `npm run build` |
-| `backend` | ubuntu-latest | Python 3.12, PostGIS + Redis 7 service containers. `ruff check` → `ruff format --check` → `pytest -v --tb=short` (8 test files excluded) |
+| `backend` | ubuntu-latest | Python 3.12, PostGIS + Redis 7 service containers. `KEYCLOAK_CLIENT_ID`/`KEYCLOAK_AUDIENCE` are set to `wims-web`/`wims-web`; Direct Grant tests scope `bfp-client` separately. `ruff check` → `ruff format --check` → `pytest -v --tb=short` (8 test files excluded) |
 | `docker-build` | ubuntu-latest | `docker compose config` validation + `docker compose build --parallel` |
 | `security-scan` | ubuntu-latest | OWASP ZAP baseline scan + Nmap port scan. Uses `.zap/rules.tsv` to ignore 7 pre-existing WARN alerts (CSP/COEP headers, Keycloak upstream, Next.js informational). Uses `zaproxy/action-baseline@v0.15.0` plus explicit artifact name `zap-scan` to avoid legacy artifact-upload rejection in older ZAP action packaging. `fail_action: true` — only new HIGH/CRITICAL block merge. |
 | `merge-gate` | ubuntu-latest | **Blocks merge** unless migrations, frontend, backend, docker-build, and security-scan all pass |
@@ -183,9 +183,9 @@ Uses `unittest.mock` (MagicMock, patch), `tmp_path`, `monkeypatch`. No database 
 
 **Trigger:** Push to `master` only
 
-The deploy workflow has a `ci` gate before SSH deployment. The backend test step runs on the GitHub runner, so it must use GitHub Actions service containers rather than Docker Compose service DNS names. The gate now provisions PostGIS (`localhost:5432`) and Redis (`localhost:6379`), initializes `wims_test` by applying `src/postgres-init/*.sql` in lexical order, and runs the same backend pytest exclusion set used by `.github/workflows/ci.yml`.
+The deploy workflow has a `ci` gate before SSH deployment. The backend test step runs on the GitHub runner, so it must use GitHub Actions service containers rather than Docker Compose service DNS names. The gate now provisions PostGIS (`localhost:5432`) and Redis (`localhost:6379`), initializes `wims_test` by applying `src/postgres-init/*.sql` in lexical order, sets backend auth envs to `wims-web`/`wims-web`, and runs the same backend pytest exclusion set used by `.github/workflows/ci.yml`.
 
-The SSH deployment step exports production secrets such as `DATABASE_URL`, `REDIS_URL`, Keycloak settings, and `WIMS_MASTER_KEY`, then updates `/opt/wims-bfp` from `origin/master` with `git fetch` + `git checkout -B master origin/master`. This avoids ambiguous `git pull` behavior on a VPS checkout after a force-updated remote. It performs a pre-deploy database connectivity check from the backend container before rebuilding and restarting the backend service. The rollback-tag step uses Docker's quiet image output directly, avoiding a `jq` dependency on the VPS.
+The SSH deployment step exports production secrets such as `DATABASE_URL`, `REDIS_URL`, Keycloak realm URL, and `WIMS_MASTER_KEY`, plus the non-secret web OIDC defaults `KEYCLOAK_CLIENT_ID=wims-web` and `KEYCLOAK_AUDIENCE=wims-web`; then it updates `/opt/wims-bfp` from `origin/master` with `git fetch` + `git checkout -B master origin/master`. This avoids ambiguous `git pull` behavior on a VPS checkout after a force-updated remote. It performs a pre-deploy database connectivity check from the backend container before rebuilding and restarting the backend service. The rollback-tag step uses Docker's quiet image output directly, avoiding a `jq` dependency on the VPS.
 
 Post-restart health polling uses a 15-second settle delay plus 45 iterations × 2s = 90s total capacity. The health check is performed inside the `wims-backend` container using Python/httpx against `http://localhost:8000/health` (the backend's actual route). This avoids depending on curl being installed in the container, bypasses the nginx proxy (which forwards the full `/api/health` path, causing 404 since the backend route is `/health`), and checks the backend directly from within its own network namespace. The `/health` endpoint is served directly by nginx at line 16 of `nginx.conf` for external uptime monitors.
 

--- a/system-wiki/backend/backend-infrastructure.md
+++ b/system-wiki/backend/backend-infrastructure.md
@@ -1,7 +1,7 @@
 ---
 title: Backend Infrastructure — Auth, Database, Entry Point, Models, Schemas, Celery
 created: 2026-05-16
-updated: 2026-05-16
+updated: 2026-06-03
 type: backend
 tags: [wims-bfp, backend, auth, database, models, schemas, celery, infrastructure]
 sources: [src/backend/auth.py, src/backend/database.py, src/backend/main.py, src/backend/models/, src/backend/schemas/, src/backend/celery_config.py]
@@ -103,7 +103,7 @@ No explicit middleware/lifespan/exception handlers configured in this file.
 
 ### Rate Limiter
 
-Lua-based sliding window on `POST /api/auth/login`. Key: `rate_limit:{client_ip}`. Config: `RATE_LIMIT_THRESHOLD=5`, `WINDOW_SECONDS=900` (15 min). Returns 429 with Retry-After header. Fail-open on Redis down.
+Lua-based sliding window on `POST /api/auth/callback`. Key: `rate_limit:{client_ip}`. Config: `RATE_LIMIT_THRESHOLD=5`, `WINDOW_SECONDS=900` (15 min). Returns 429 with Retry-After header. Fail-open on Redis down. In the normal browser path, Next.js `/api/auth/sync` forwards nginx-provided client IP headers to preserve per-client limiter granularity before calling the backend callback.
 
 ### Route Registration
 

--- a/system-wiki/index.md
+++ b/system-wiki/index.md
@@ -1,14 +1,14 @@
 # WIMS-BFP System Wiki Index
 
-Last updated: 2026-05-30
+Last updated: 2026-06-03
 Total synthesis pages: 32
-Last changes: VPS nginx TLS recovery was clarified with explicit production Compose commands and Make targets. Public Fire Report Areas implementation contract was repaired and localhost nginx moved to a local-only override. Archived encoder/validator incidents can be opened from archive views, restored with unarchive actions, and pass the verified-row immutability rule in both archive directions.
+Last changes: PR #214 fix-before-merge pass aligned CI/deploy Keycloak defaults to `wims-web`, pinned nginx, updated auth callback rate-limit docs/tests, documented local HTTP-only nginx development, and refreshed Suricata/nginx image references.
 Purpose: project-local knowledgebase for agents routing themselves to relevant WIMS-BFP context.
 
 ## Start Here
 - [[mocs/system-map]] — primary map of content and routing entry point.
 - [[operations/agent-routing-guide]] — which page an agent should read before touching each subsystem.
-- [[operations/local-dev-deploy-guide]] — clean-slate local deployment on Windows: one-time SSL setup, known pitfalls (CRLF scripts, missing cert, password policy), seed users, verification.
+- [[operations/local-dev-deploy-guide]] — clean-slate local deployment on Windows: local HTTP-only nginx override, known pitfalls (CRLF scripts, accidental production TLS config, password policy), seed users, verification.
 
 ## Architecture
 - [[architecture/system-overview]] — Dockerized full-stack architecture, runtime services, and evidence sources.

--- a/system-wiki/log.md
+++ b/system-wiki/log.md
@@ -3,6 +3,15 @@
 Chronological record of system-wiki changes. Append-only.
 Format: `## [YYYY-MM-DD] action | subject`
 
+## [2026-06-03] fix | PR #214 infra/auth config review fixes
+
+- Updated the manual auth rate-limit test to target the real `POST /api/auth/callback` protected path instead of the stale `/api/auth/login` stub.
+- Aligned CI/deploy backend auth env defaults to `KEYCLOAK_CLIENT_ID=wims-web` and `KEYCLOAK_AUDIENCE=wims-web`; scoped Direct Grant password-reset verification to `KEYCLOAK_PASSWORD_RESET_CLIENT_ID` (`bfp-client` by default).
+- Pinned `nginx-gateway` to `nginx:1.27.3-alpine` and refreshed Suricata/nginx image references in `architecture/infrastructure-config.md`.
+- Updated `src/frontend/src/app/api/auth/sync/route.ts` to forward trusted nginx client-IP headers to backend `/api/auth/callback` so Redis callback rate limiting keys by end-user IP rather than the frontend container.
+- Repaired local-dev docs to remove obsolete self-signed-cert setup for base compose and documented the production-only TLS mount split.
+- Clarified that the admin `rate_limit_config:login` key/tier is a legacy compatibility label for the auth callback flow.
+
 ## [2026-06-03] fix | CI security scan — ZAP artifact upload compatibility
 
 - Updated `.github/workflows/ci.yml` `security-scan` ZAP baseline action to set `artifact_name: 'zap-scan'` and bump `zaproxy/action-baseline` from `v0.12.0` to `v0.15.0`, avoiding the legacy action packaging that failed during GitHub artifact container creation.

--- a/system-wiki/operations/local-dev-deploy-guide.md
+++ b/system-wiki/operations/local-dev-deploy-guide.md
@@ -1,7 +1,7 @@
 ---
 title: Local Dev Deployment Guide
 created: 2026-05-27
-updated: 2026-05-30
+updated: 2026-06-03
 type: operations
 tags: [wims-bfp, docker, deployment, local-dev, windows, troubleshooting]
 sources: [src/docker-compose.yml, src/nginx/nginx.conf, src/keycloak/bootstrap/bootstrap-master-realm.sh, scripts/seed-dev-users.sh, CLAUDE.md]
@@ -17,29 +17,20 @@ This page exists to prevent future agents from rediscovering the same pitfalls w
 ## TL;DR — The Correct Sequence
 
 ```bash
-# 1. One-time local SSL setup (only needed on first clone or after volume wipe)
-#    Skip if src/.ssl/live/wimsbfp.tech/fullchain.pem already exists.
-mkdir -p src/.ssl/live/wimsbfp.tech
-MSYS_NO_PATHCONV=1 openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-  -keyout src/.ssl/live/wimsbfp.tech/privkey.pem \
-  -out src/.ssl/live/wimsbfp.tech/fullchain.pem \
-  -subj "/CN=localhost"
-echo "LETSENCRYPT_DIR=./.ssl" >> src/.env
-
-# 2. Fresh build (from repo root, not src/)
+# 1. Fresh build (from repo root, not src/)
 cd src && docker compose down -v
 cd src && docker compose build --no-cache
 cd src && docker compose up -d
 
-# 3. Wait for stack to stabilize, then seed dev users
+# 2. Wait for stack to stabilize, then seed dev users
 #    (run from project root, not src/)
 bash scripts/seed-dev-users.sh
 
-# 4. Verify
-curl -sk https://localhost/health
+# 3. Verify
+curl -s http://localhost/health
 ```
 
-If all containers are green and `{"status":"ok","via":"nginx-gateway"}` is returned, the stack is up. Dev users are available at `https://localhost` with password **`Password123!`**.
+If all containers are green and `{"status":"ok","via":"nginx-gateway"}` is returned, the local HTTP stack is up. Dev users are available at `http://localhost` with password **`Password123!`**.
 
 ---
 
@@ -48,40 +39,17 @@ If all containers are green and `{"status":"ok","via":"nginx-gateway"}` is retur
 | Tool | Notes |
 |------|-------|
 | Docker Desktop | Must be running. WSL2 backend recommended. |
-| `openssl` | Comes with Git for Windows; run from Git Bash. |
 | `bash` | Git Bash or WSL2 shell for the seed script. |
 
 ---
 
 ## Step-by-Step
 
-### 1. One-time SSL cert setup (local dev only)
+### 1. Local nginx mode
 
-`src/docker-compose.yml` mounts `${LETSENCRYPT_DIR:-/opt/wims-bfp/letsencrypt}` into the nginx container as `/etc/letsencrypt`. On the VPS this path holds the real Let's Encrypt cert. Locally, neither the default `/opt/wims-bfp/letsencrypt` path nor the cert exist, so nginx exits immediately with:
+Local development no longer requires generating self-signed certificates just to satisfy the base Compose file. The base `src/docker-compose.yml` keeps only the nginx config mount, and the automatically loaded `src/docker-compose.override.yml` swaps in `src/nginx/nginx.local.conf`, which serves HTTP on port 80 without TLS certificate paths. Production TLS certs are mounted only by `src/docker-compose.prod.yml` or an explicit deployment override.
 
-```
-cannot load certificate "/etc/letsencrypt/live/wimsbfp.tech/fullchain.pem"
-```
-
-**Fix:** generate a self-signed cert and point the env var at it:
-
-```bash
-mkdir -p src/.ssl/live/wimsbfp.tech
-MSYS_NO_PATHCONV=1 openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-  -keyout src/.ssl/live/wimsbfp.tech/privkey.pem \
-  -out src/.ssl/live/wimsbfp.tech/fullchain.pem \
-  -subj "/CN=localhost"
-```
-
-Then add to `src/.env`:
-
-```
-LETSENCRYPT_DIR=./.ssl
-```
-
-`src/.ssl/` is gitignored. Run this once per machine. The cert lasts 365 days.
-
-> **Why `MSYS_NO_PATHCONV=1`?** Git Bash on Windows converts leading `/` to a Windows drive path (e.g., `/CN=localhost` → `C:\Program Files\Git\CN=localhost`). The env var disables that conversion for the single command.
+Do not add `LETSENCRYPT_DIR=./.ssl` to `src/.env` for routine local development. If nginx fails locally with `cannot load certificate "/etc/letsencrypt/live/wimsbfp.tech/fullchain.pem"`, it is using the production nginx config by mistake; recreate with plain `docker compose up -d` from `src/` so the local override is loaded, or remove any explicit production compose flags.
 
 ### 2. Clean-slate build
 
@@ -122,9 +90,9 @@ Password for all: **`Password123!`**
 ### 4. Verify
 
 ```bash
-curl -sk https://localhost/health          # nginx: {"status":"ok","via":"nginx-gateway"}
-curl -sk https://localhost/ -o /dev/null -w "%{http_code}\n"  # 200 (frontend)
-curl -sk https://localhost/api/incidents -o /dev/null -w "%{http_code}\n"  # 401 (backend auth guard)
+curl -s http://localhost/health          # nginx: {"status":"ok","via":"nginx-gateway"}
+curl -s http://localhost/ -o /dev/null -w "%{http_code}\n"  # 200 (frontend)
+curl -s http://localhost/api/incidents -o /dev/null -w "%{http_code}\n"  # 401 (backend auth guard)
 curl -sk http://localhost:8080/auth/realms/bfp/.well-known/openid-configuration -o /dev/null -w "%{http_code}\n"  # 200 (Keycloak)
 ```
 
@@ -152,28 +120,19 @@ sed -i 's/\r//' src/backend/wait-for-db.sh
 
 **What success looks like:** `wims-keycloak-bootstrap` logs end with `Keycloak master realm bootstrap complete` and the container exits 0. The `set: -: invalid option` lines that appear above it are from a previous failed run; docker compose logs aggregate across restarts.
 
-### Pitfall 2 — `wims-nginx-gateway` exits 1
+### Pitfall 2 — `wims-nginx-gateway` exits 1 with missing certificate errors
 
-**Symptom:** `docker compose ps -a` shows `wims-nginx-gateway Exited (1)`. Ports 80/443 are not open.
+**Symptom:** `docker compose ps -a` shows `wims-nginx-gateway Exited (1)` and logs mention `/etc/letsencrypt/live/wimsbfp.tech/fullchain.pem`.
 
-**Root cause:** `src/nginx/nginx.conf` requires TLS certs at `/etc/letsencrypt/live/wimsbfp.tech/fullchain.pem`. The compose file mounts `${LETSENCRYPT_DIR:-/opt/wims-bfp/letsencrypt}` — on a dev machine neither the env var nor the default path holds real certs.
+**Root cause:** The local stack is loading the production TLS nginx config instead of the local HTTP-only override. The base compose no longer mounts Let's Encrypt certificates; `src/docker-compose.prod.yml` is the only committed compose file that mounts `/etc/letsencrypt`.
 
-**Fix:** do the one-time SSL setup in step 1 above. If you've already done it, check:
+**Fix:** for local development, run plain Compose from `src/` so `docker-compose.override.yml` mounts `src/nginx/nginx.local.conf`:
 
 ```bash
-ls src/.ssl/live/wimsbfp.tech/      # fullchain.pem and privkey.pem must exist
-grep LETSENCRYPT_DIR src/.env        # must be present and point to ./.ssl
+cd src && docker compose up -d --force-recreate nginx-gateway
 ```
 
-If the env var is missing from `src/.env`, add it:
-
-```
-LETSENCRYPT_DIR=./.ssl
-```
-
-Then restart just nginx: `cd src && docker compose up -d nginx-gateway`.
-
-> **Note:** `src/.ssl/` is gitignored and not committed. Each developer machine needs to run the `openssl` command once. The cert is self-signed so browsers will warn — accept the exception for `https://localhost`.
+If you intentionally need the production TLS config, use the production command with a real `LETSENCRYPT_DIR` as described below instead of generating repo-local self-signed certs.
 
 ### Pitfall 3 — `seed-dev-users.sh` fails with password policy error
 


### PR DESCRIPTION
## Slice 2 — Infrastructure & Config

Four fixes from the three-axis review backlog:

### #186 — Pin Docker image tags
- `ollama/ollama:latest` → `ollama/ollama:0.5.1`
- `jasonish/suricata:latest` → `jasonish/suricata:7.0.5`

### #191 — Fix nginx local development
- Removed unconditional Let's Encrypt TLS cert mount from base compose
- Production TLS certs should be mounted via deployment override
- `docker-compose.override.yml` already handles local nginx config

### #194 — Fix .env.example audience mismatch
- Changed defaults from `bfp-client`/`account` → `wims-web`/`wims-web`
- Both `.env.example` and `auth.py` defaults now match the Keycloak realm config

### #189 — Fix rate limiting to protect real PKCE callback
- Rate limiter now protects `/api/auth/callback` instead of the stub `/api/auth/login`
- The login stub endpoint is covered by issue #187 (separate fix)

Closes #186, closes #191, closes #194, closes #189