### PR TITLE
fix(slice3): backend bugs — async Redis, session DELETE, stub login, docstring, attachment ID, logger, bundle failures

### DIFF
--- a/src/backend/api/routes/admin.py
+++ b/src/backend/api/routes/admin.py
@@ -1,5 +1,5 @@
 """System Admin API — Identity, Security Telemetry, Audit Oversight.
-All endpoints protected by get_system_admin. No DELETE endpoints (Immutability Law)."""
+All endpoints protected by get_system_admin. No incident DELETE endpoints (Immutability Law)."""
 
 import json
 import logging

--- a/src/backend/api/routes/incidents.py
+++ b/src/backend/api/routes/incidents.py
@@ -113,7 +113,6 @@ def upload_incident_bundle(
         raise HTTPException(status_code=500, detail="Failed to create import batch")
 
     batch_id = int(batch_row[0])
-    incident_ids: list[int] = []
     results: dict[str, list] = {"imported": [], "failed": []}
     i = 0
 
@@ -434,6 +433,8 @@ async def upload_attachment(
                 "uid": user["user_id"],
             },
         ).fetchone()
+        if att_row is None:
+            raise HTTPException(status_code=500, detail="Attachment insert returned no row")
         attachment_id = int(att_row[0])
         db.commit()
     except Exception:

--- a/src/backend/api/routes/incidents.py
+++ b/src/backend/api/routes/incidents.py
@@ -114,6 +114,8 @@ def upload_incident_bundle(
 
     batch_id = int(batch_row[0])
     incident_ids: list[int] = []
+    results: dict[str, list] = {"imported": [], "failed": []}
+    i = 0
 
     def _safe_int(v: Any, default: int = 0) -> int:
         try:
@@ -131,6 +133,7 @@ def upload_incident_bundle(
         if not isinstance(item, dict):
             continue
 
+        i += 1
         ns = item.get("incident_nonsensitive_details") or {}
         sens = item.get("incident_sensitive_details") or {}
         if not isinstance(ns, dict):
@@ -180,10 +183,11 @@ def upload_incident_bundle(
         ).fetchone()
 
         if not inc_row:
+            results["failed"].append({"index": i, "reason": "Failed to insert incident row"})
             continue
 
         incident_id = int(inc_row[0])
-        incident_ids.append(incident_id)
+        results["imported"].append(incident_id)
 
         db.execute(
             text(
@@ -355,7 +359,7 @@ def upload_incident_bundle(
             status_code=500, detail=f"upload-bundle commit failed: {type(e).__name__}"
         ) from None
 
-    for iid in incident_ids:
+    for iid in results["imported"]:
         try:
             sync_incident_to_analytics(db, iid)
         except Exception:
@@ -365,8 +369,10 @@ def upload_incident_bundle(
     return {
         "status": "ok",
         "batch_id": batch_id,
-        "incident_ids": incident_ids,
-        "message": f"Committed {len(incident_ids)} incident(s).",
+        "imported": results["imported"],
+        "incident_ids": results["imported"],
+        "failed": results["failed"],
+        "message": f"Committed {len(results['imported'])} incident(s), {len(results['failed'])} failed.",
     }
 
 
@@ -410,13 +416,14 @@ async def upload_attachment(
 
     # 3. Record in DB
     try:
-        db.execute(
+        att_row = db.execute(
             text("""
                 INSERT INTO wims.incident_attachments (
                     incident_id, file_name, storage_path, mime_type, file_hash_sha256, uploaded_by
                 ) VALUES (
                     :iid, :fname, :path, :mime, :hash, :uid
                 )
+                RETURNING attachment_id
             """),
             {
                 "iid": incident_id,
@@ -426,7 +433,8 @@ async def upload_attachment(
                 "hash": sha256_hash.hexdigest(),
                 "uid": user["user_id"],
             },
-        )
+        ).fetchone()
+        attachment_id = int(att_row[0])
         db.commit()
     except Exception:
         db.rollback()
@@ -437,7 +445,7 @@ async def upload_attachment(
 
     return {
         "status": "ok",
-        "attachment_id": incident_id,  # Serial ID, but we don't have it immediately without RETURNING
+        "attachment_id": attachment_id,
         "message": "Attachment uploaded successfully",
     }
 

--- a/src/backend/api/routes/sessions.py
+++ b/src/backend/api/routes/sessions.py
@@ -43,15 +43,14 @@ def list_user_sessions(
     return {"sessions": sessions}
 
 
-@router.delete("/sessions/{user_id}/{session_id}")
-def terminate_user_session(
+@router.delete("/sessions/{user_id}")
+def terminate_user_sessions(
     user_id: str,
-    session_id: str,
     _admin: Annotated[dict, Depends(get_system_admin)],
     db: Annotated[Session, Depends(get_db_with_rls)],
 ):
     """
-    Terminate sessions for a user (by internal WIMS user_id). Admin only.
+    Terminate all sessions for a user (by internal WIMS user_id). Admin only.
     Note: python-keycloak does not expose a single-session revoke endpoint,
     so this terminates ALL sessions for the user.
     """

--- a/src/backend/api/routes/sessions.py
+++ b/src/backend/api/routes/sessions.py
@@ -53,6 +53,8 @@ def terminate_user_sessions(
     Terminate all sessions for a user (by internal WIMS user_id). Admin only.
     Note: python-keycloak does not expose a single-session revoke endpoint,
     so this terminates ALL sessions for the user.
+    For single-session revocation, use
+    DELETE /api/admin/sessions/{user_id}/{session_id} (in admin.py).
     """
     keycloak_id = _resolve_keycloak_id(user_id, db)
     logout_user_sessions(keycloak_id)

--- a/src/backend/auth.py
+++ b/src/backend/auth.py
@@ -2,6 +2,7 @@ import os
 import time
 import uuid
 import logging
+import asyncio
 from typing import Annotated, Optional, Dict, Any
 from jose import jwt, jwk, JWTError
 import httpx
@@ -215,7 +216,7 @@ class KeycloakAuthenticator:
                     # --- Instant Revocation Check ---
                     sub = payload.get("sub")
                     iat = payload.get("iat")
-                    if sub and iat and session_manager.is_token_revoked(sub, iat):
+                    if sub and iat and await asyncio.to_thread(session_manager.is_token_revoked, sub, iat):
                         logger.warning(f"Rejecting revoked token for user sub={sub}")
                         raise HTTPException(
                             status_code=401,

--- a/src/backend/auth.py
+++ b/src/backend/auth.py
@@ -216,7 +216,11 @@ class KeycloakAuthenticator:
                     # --- Instant Revocation Check ---
                     sub = payload.get("sub")
                     iat = payload.get("iat")
-                    if sub and iat and await asyncio.to_thread(session_manager.is_token_revoked, sub, iat):
+                    if (
+                        sub
+                        and iat
+                        and await asyncio.to_thread(session_manager.is_token_revoked, sub, iat)
+                    ):
                         logger.warning(f"Rejecting revoked token for user sub={sub}")
                         raise HTTPException(
                             status_code=401,

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -61,6 +61,9 @@ from api.routes.geocode import router as geocode_router
 from auth import resolve_wims_role_from_token as _resolve_role_from_token
 from utils.csrf import csrf_middleware
 
+# Module-level logger — must be defined before use in schema patches and rate limiter
+logger = logging.getLogger("wims.rate_limit")
+
 
 # ---------------------------------------------------------------------------
 # App
@@ -130,8 +133,6 @@ app.include_router(validator_map_router)  # GET /api/validator/operational-map (
 app.include_router(
     geocode_router
 )  # GET /api/geocode/reverse, /api/geocode/search (Nominatim proxy)
-
-logger = logging.getLogger("wims.rate_limit")
 
 # ---------------------------------------------------------------------------
 # Celery
@@ -301,16 +302,6 @@ async def metrics_endpoint():
 
 # ---------------------------------------------------------------------------
 # Routes
-# ---------------------------------------------------------------------------
-@app.post("/api/auth/login")
-async def login():
-    """Stub login — always rejects with 401 (no auth backend wired yet)."""
-    return JSONResponse(
-        status_code=401,
-        content={"detail": "Invalid credentials"},
-    )
-
-
 # ---------------------------------------------------------------------------
 # Auth Callback (PKCE → Keycloak → Identity Sync)
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/test_csrf_middleware.py
+++ b/src/backend/tests/test_csrf_middleware.py
@@ -27,7 +27,7 @@ def _reset_csrf_cache():
 @pytest.fixture(autouse=True)
 def _disable_rate_limiter(monkeypatch: pytest.MonkeyPatch):
     """Mock Redis unavailable so the rate-limiter fail-opens for every test.
-    Without this, repeated POSTs to /api/auth/login hit the sliding-window
+    Without this, repeated POSTs to /api/auth/callback hit the sliding-window
     threshold (5 req/15min) and return 429 instead of the expected CSRF or auth response.
     """
 
@@ -149,14 +149,14 @@ class TestSafeMethods:
 class TestPostOriginValidation:
     def test_post_rejected_without_origin(self):
         """POST with neither Origin nor Referer → 403"""
-        resp = CLIENT.post("/api/auth/login", json={}, headers={})
+        resp = CLIENT.post("/api/auth/callback", json={}, headers={})
         assert resp.status_code == 403
         assert "CSRF validation failed" in resp.text
 
     def test_post_rejected_invalid_origin(self):
         """POST from evil.com → 403"""
         resp = CLIENT.post(
-            "/api/auth/login",
+            "/api/auth/callback",
             json={},
             headers={"origin": "https://evil.com"},
         )
@@ -166,7 +166,7 @@ class TestPostOriginValidation:
     def test_post_rejected_malformed_origin(self):
         """POST from gibberish origin → 403"""
         resp = CLIENT.post(
-            "/api/auth/login",
+            "/api/auth/callback",
             json={},
             headers={"origin": "this-is-not-a-url"},
         )
@@ -175,41 +175,41 @@ class TestPostOriginValidation:
     def test_post_accepted_with_valid_origin(self):
         """POST from localhost → passes CSRF (hits route handler)"""
         resp = CLIENT.post(
-            "/api/auth/login",
+            "/api/auth/callback",
             json={},
             headers={"origin": "http://localhost"},
         )
-        # Should not be 403 — CSRF passed. 401 from stub auth is expected.
+        # Should not be 403 — CSRF passed. 422 from auth callback body validation is expected.
         assert resp.status_code != 403
-        assert resp.status_code == 401
+        assert resp.status_code == 422
 
     def test_post_accepted_with_https_localhost(self):
         """POST from https://localhost → passes CSRF"""
         resp = CLIENT.post(
-            "/api/auth/login",
+            "/api/auth/callback",
             json={},
             headers={"origin": "https://localhost"},
         )
-        assert resp.status_code == 401  # stub auth, not CSRF block
+        assert resp.status_code == 422  # auth callback body validation, not CSRF block
 
     def test_post_with_referer_valid(self):
         """POST with only Referer (matching localhost) → passes CSRF"""
         resp = CLIENT.post(
-            "/api/auth/login",
+            "/api/auth/callback",
             json={},
             headers={"referer": "http://localhost/login"},
         )
-        assert resp.status_code == 401  # stub auth, not CSRF block
+        assert resp.status_code == 422  # auth callback body validation, not CSRF block
 
     def test_post_accepted_https_default_port(self):
         """POST from https://localhost:443 → port stripped, origin matches.
         Browsers may send the default port in the Origin header."""
         resp = CLIENT.post(
-            "/api/auth/login",
+            "/api/auth/callback",
             json={},
             headers={"origin": "https://localhost:443"},
         )
-        assert resp.status_code == 401  # stub auth, not CSRF block
+        assert resp.status_code == 422  # auth callback body validation, not CSRF block
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +221,7 @@ class TestOtherUnsafeMethods:
     def test_put_rejected_invalid_origin(self):
         """PUT with invalid origin → 403"""
         resp = CLIENT.put(
-            "/api/auth/login",
+            "/api/auth/callback",
             json={},
             headers={"origin": "https://evil.com"},
         )
@@ -230,7 +230,7 @@ class TestOtherUnsafeMethods:
     def test_patch_rejected_invalid_origin(self):
         """PATCH with invalid origin → 403"""
         resp = CLIENT.patch(
-            "/api/auth/login",
+            "/api/auth/callback",
             json={},
             headers={"origin": "https://attacker.org"},
         )
@@ -239,7 +239,7 @@ class TestOtherUnsafeMethods:
     def test_delete_rejected_invalid_origin(self):
         """DELETE with invalid origin → 403"""
         resp = CLIENT.delete(
-            "/api/auth/login",
+            "/api/auth/callback",
             headers={"origin": "https://evil.net"},
         )
         assert resp.status_code == 403
@@ -247,7 +247,7 @@ class TestOtherUnsafeMethods:
     def test_put_accepted_valid_referer(self):
         """PUT with valid Referer → passes CSRF"""
         resp = CLIENT.put(
-            "/api/auth/login",
+            "/api/auth/callback",
             json={},
             headers={"referer": "https://localhost/"},
         )
@@ -256,7 +256,7 @@ class TestOtherUnsafeMethods:
     def test_patch_accepted_valid_origin(self):
         """PATCH with valid Origin → passes CSRF"""
         resp = CLIENT.patch(
-            "/api/auth/login",
+            "/api/auth/callback",
             json={},
             headers={"origin": "http://localhost"},
         )
@@ -277,7 +277,7 @@ class TestProductionOrigin:
 
             m._allowed_origins = None
             resp = CLIENT.post(
-                "/api/auth/login",
+                "/api/auth/callback",
                 json={},
                 headers={"origin": "https://wimsbfp.tech"},
             )
@@ -291,7 +291,7 @@ class TestProductionOrigin:
 
             m._allowed_origins = None
             resp = CLIENT.post(
-                "/api/auth/login",
+                "/api/auth/callback",
                 json={},
                 headers={"origin": "https://wimsbfp.tech:8443"},
             )
@@ -309,7 +309,8 @@ class TestPublicDmzCsrfExemption:
         The public DMZ is unauthenticated/no-cookie; CSRF is not meaningful.
         Without a DB mock the request will hit the real DB and likely get 500,
         but it must NOT be a CSRF 403."""
-        resp = CLIENT.post(
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
             "/api/v1/public/report",
             json={
                 "latitude": 14.5995,
@@ -321,10 +322,10 @@ class TestPublicDmzCsrfExemption:
         assert resp.status_code != 403, f"Public DMZ should be CSRF-exempt but got 403: {resp.text}"
 
     def test_auth_post_without_origin_still_blocked(self):
-        """POST /api/auth/login without Origin/Referer must still return 403.
+        """POST /api/auth/callback without Origin/Referer must still return 403.
         The CSRF exemption only applies to public DMZ paths."""
         resp = CLIENT.post(
-            "/api/auth/login",
+            "/api/auth/callback",
             json={},
             headers={},
         )

--- a/system-wiki/backend/backend-infrastructure.md
+++ b/system-wiki/backend/backend-infrastructure.md
@@ -122,8 +122,6 @@ Lua-based sliding window on `POST /api/auth/callback`. Key: `rate_limit:{client_
 
 ### Endpoints Defined Directly in main.py
 
-**`POST /api/auth/login`** — stub, always returns 401.
-
 **`POST /api/auth/callback`** — PKCE handshake. Exchanges code for tokens via Keycloak token endpoint, validates via `auth.authenticator.validate_token()`, resolves role from JWT, upserts `wims.users`, returns `{access_token, refresh_token, user_id}`.
 
 **`GET /api/user/me`** — Returns merged JWT + wims.users payload. JIT-provisions user if not in database.

--- a/system-wiki/log.md
+++ b/system-wiki/log.md
@@ -1896,3 +1896,15 @@ Implemented verified PR #207 review fixes across profile email handling and docu
 **Rate-limit test resolution:** The stale `test_rate_limiting.py` (targeted removed `/api/auth/login`) was not deleted — master had already rewritten it to target `POST /api/auth/callback` and mark it as a manual live-stack check excluded from CI. PR #215 retains master's callback-targeted manual test.
 
 **Files:** `auth.py`, `main.py`, `incidents.py`, `sessions.py`, `admin.py`
+
+## [2026-06-05] fix | PR #215 — CSRF test alignment with removed stub login
+
+Updated `src/backend/tests/test_csrf_middleware.py` to match PR #215's removal of the stub `/api/auth/login` endpoint:
+- Replaced all 17 `/api/auth/login` references with the live `/api/auth/callback` route.
+- The 4 valid-origin POST acceptance tests now assert `status_code == 422` (Pydantic validation for empty `AuthCallbackRequest` body) instead of the old `== 401` from the removed stub.
+- CSRF rejection tests (no/invalid origin) continue to assert `status_code == 403`.
+- PUT/PATCH/DELETE valid-origin tests assert `!= 403` (CSRF passed) regardless of downstream route response.
+- The public DMZ exemption test now uses `TestClient(..., raise_server_exceptions=False)` so local no-DB runs can inspect the non-403 response instead of raising a connection exception.
+- Fixture docstrings updated from "stub auth" to "auth callback body validation" wording.
+
+**Wiki update:** Removed stale `POST /api/auth/login` endpoint documentation from `system-wiki/backend/backend-infrastructure.md`. No FRS/codebase gap change.

--- a/system-wiki/log.md
+++ b/system-wiki/log.md
@@ -1879,3 +1879,20 @@ Implemented verified PR #207 review fixes across profile email handling and docu
 - Restored the base-branch append-only log history, preserving PR #207 entries at the end instead of before the append-only banner.
 
 **Wiki updates:** Updated `backend/remaining-routes.md`, `frontend/route-map.md`, `database/schema-overview.md`, `security/security-baseline.md`, `architecture/pwa-tests-cicd.md`, `index.md`, and this log. No `gaps/frs-codebase-gap-register.md` update needed; no FRS/codebase gap changed. Self-service email verification remains a residual follow-up because enabling Keycloak verify-email/required action safely would affect realm/admin flow behavior beyond this bounded PR fix.
+
+## [2026-06-05] fix | Slice 3 — backend bugs & cleanup (PR #215, rebased onto origin/master)
+
+**Fixes across 7 issues:**
+- #183: Wrapped sync `is_token_revoked()` in `asyncio.to_thread()` to avoid event loop blocking.
+- #185: Renamed `DELETE /sessions/{user_id}/{session_id}` → `/sessions/{user_id}` to match bulk-termination behavior.
+- #187: Removed stub `/api/auth/login` always-401 endpoint; retargeted rate limiter to `/api/auth/callback`.
+- #188: Fixed admin.py docstring from "No DELETE endpoints" → "No incident DELETE endpoints".
+- #193: Added `RETURNING attachment_id` to attachment INSERT; returns actual DB ID now.
+- #197: Moved logger definition before `apply_schema_patches()` in main.py.
+- #200: Bundle upload now reports failed incidents with index + reason; `incident_ids` kept for backward compat.
+
+**Review fixes applied during rebase:** Orphaned `incident_ids` variable removed, null-guard on attachment RETURNING added, docstring clarified to point to admin.py single-session route.
+
+**Rate-limit test resolution:** The stale `test_rate_limiting.py` (targeted removed `/api/auth/login`) was not deleted — master had already rewritten it to target `POST /api/auth/callback` and mark it as a manual live-stack check excluded from CI. PR #215 retains master's callback-targeted manual test.
+
+**Files:** `auth.py`, `main.py`, `incidents.py`, `sessions.py`, `admin.py`


### PR DESCRIPTION
## Slice 3 — Backend Bugs & Cleanup

Seven fixes from the three-axis review backlog:

### #183 — Fix async event loop blocking
Wrapped sync `session_manager.is_token_revoked()` in `asyncio.to_thread()` to avoid blocking the async event loop on every token validation.

### #185 — Fix session DELETE path
`DELETE /sessions/{user_id}/{session_id}` terminated ALL user sessions. Renamed to `DELETE /sessions/{user_id}` and function to `terminate_user_sessions` to match actual bulk behavior.

### #187 — Remove stub login endpoint
Deleted the `POST /api/auth/login` stub that always returned 401. Updated rate limiter from `/api/auth/login` → `/api/auth/callback`.

### #188 — Fix misleading docstring
Admin.py said "No DELETE endpoints (Immutability Law)" but session management DELETE exists. Updated to "No incident DELETE endpoints".

### #193 — Fix attachment returning wrong ID
`upload_attachment` returned `incident_id` as `attachment_id`. Added `RETURNING attachment_id` to the INSERT query.

### #197 — Reorder logger initialization
Logger was defined at line 126 but used at line 99 in `apply_schema_patches()`. Moved to top of module.

### #200 — Fix incident bundle upload
Silent `continue` on failed inserts now tracked as `results.failed` with index + reason. Imported IDs moved to `results.imported`. Response includes both lists.

Closes #183, closes #185, closes #187, closes #188, closes #193, closes #197, closes #200