### PR TITLE
feat: implement CSRF protection — SameSite cookies, Origin/Referer va…

### DIFF
--- a/docs/pentest/CSRF-CHECKLIST.md
+++ b/docs/pentest/CSRF-CHECKLIST.md
@@ -1,0 +1,52 @@
+# CSRF Penetration Testing Checklist — Module 11b
+
+## Cookie Attributes
+
+- [ ] `__Host-access_token` cookie has `Secure; HttpOnly; SameSite=Strict; Path=/`
+- [ ] `__Host-refresh_token` cookie has `Secure; HttpOnly; SameSite=Strict; Path=/`
+- [ ] No `Domain` attribute set (enforces `__Host-` prefix semantics)
+- [ ] Both cookies cleared on logout (`maxAge=0`)
+
+## Origin/Referer Validation
+
+- [ ] POST without `Origin` or `Referer` → `403 "CSRF validation failed: missing origin header"`
+- [ ] POST from untrusted origin (e.g., `https://evil.com`) → `403 "CSRF validation failed: untrusted origin"`
+- [ ] POST from same origin (`https://wimsbfp.tech` or `http://localhost`) → passes CSRF middleware (hits auth guard as normal)
+- [ ] PUT/PATCH/DELETE from untrusted origin → `403`
+- [ ] GET/HEAD/OPTIONS requests bypass CSRF entirely
+- [ ] SSE `/api/events/stream` GET connects successfully (SameSite=Strict + safe method)
+
+## Cross-Origin Attack Simulation
+
+- [ ] Cross-origin `<form>` POST to `/api/admin/users` → cookies NOT sent (SameSite=Strict)
+- [ ] Cross-origin `fetch()` with `credentials: 'include'` to `/api/regional/incidents` → blocked (Origin check)
+- [ ] Cross-origin top-level navigation to `/dashboard` → cookies NOT sent (SameSite=Strict)
+- [ ] Subdomain cookie injection: attacker cannot set `__Host-*` cookie for parent domain (`__Host-` prefix prevents this)
+
+## CORS
+
+- [ ] Nginx returns `Access-Control-Allow-Origin: $scheme://$host` (not wildcard `$http_origin`)
+- [ ] Preflight OPTIONS returns same restricted origin
+
+## OIDC Flow Integrity
+
+- [ ] Login flow through Keycloak redirect (same-origin `/auth/` path) completes successfully
+- [ ] Callback at `/callback` sets `__Host-access_token` and `__Host-refresh_token` correctly
+- [ ] Token refresh works (cookie-based, same-origin POST to `/api/auth/refresh`)
+- [ ] Force-logout from admin panel clears both cookies
+- [ ] Tab-coordinated refresh (`navigator.locks`) still works with SameSite=Strict
+
+## Test Coverage
+
+- [ ] Backend `pytest tests/test_csrf_middleware.py -v` passes all cases
+- [ ] Frontend `npx vitest run src/app/api/auth/session/route.test.ts` passes
+
+## Remediation Escalation
+
+| Finding | Severity | Timeline |
+|---------|----------|----------|
+| Missing SameSite=Strict | High | 7 days |
+| Missing Origin/Referer validation | High | 7 days |
+| CORS wildcard `$http_origin` | Medium | 30 days |
+| Missing CSRF test cases | Low | 90 days |
+| No `__Host-` prefix on cookies | Medium | 30 days |

--- a/src/backend/auth.py
+++ b/src/backend/auth.py
@@ -291,9 +291,10 @@ async def get_current_user(request: Request):
     """
     Extract and validate the access_token from HttpOnly cookies only.
     The Authorization header is NOT consulted — HttpOnly cookies are the
-    sole token transport to prevent XSS-driven token theft (CSRF mitigation).
+    sole token transport (XSS-resistant). CSRF is mitigated by SameSite=Strict,
+    __Host- cookie prefix, and Origin/Referer middleware.
     """
-    token = request.cookies.get("access_token")
+    token = request.cookies.get("__Host-access_token")
     if not token:
         raise HTTPException(status_code=401, detail="Authentication credentials missing")
 

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -58,12 +58,14 @@ from api.routes.geocode import router as geocode_router
 
 # WIMS role resolution — canonical source in auth.py
 from auth import resolve_wims_role_from_token as _resolve_role_from_token
+from utils.csrf import CSRFMiddleware
 
 
 # ---------------------------------------------------------------------------
 # App
 # ---------------------------------------------------------------------------
 app = FastAPI(title="WIMS-BFP Backend")
+app.add_middleware(CSRFMiddleware)
 
 
 @app.on_event("startup")

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -64,3 +64,17 @@ except ImportError:
     def flush_rate_limits():
         """No-op when pytest_asyncio/redis not installed."""
         return None
+
+
+# =============================================================================
+# CSRF middleware: disabled by default in test suite
+# =============================================================================
+# Existing tests send POST/PUT/PATCH/DELETE without Origin/Referer headers.
+# To keep them passing, disable CSRF enforcement globally and let the
+# dedicated test_csrf_middleware.py re-enable it per-test via MonkeyPatch.
+@pytest.fixture(autouse=True)
+def _disable_csrf():
+    """Globally disable CSRF middleware for all non-CSRF tests."""
+    os.environ["WIMS_CSRF_DISABLED"] = "1"
+    yield
+    os.environ.pop("WIMS_CSRF_DISABLED", None)

--- a/src/backend/tests/test_csrf_middleware.py
+++ b/src/backend/tests/test_csrf_middleware.py
@@ -3,8 +3,6 @@ Tests for CSRF protection middleware (__Host- cookies + Origin/Referer validatio
 Module 11b — Penetration Testing Scope: CSRF.
 """
 
-import os
-
 import pytest
 from fastapi.testclient import TestClient
 from main import app

--- a/src/backend/tests/test_csrf_middleware.py
+++ b/src/backend/tests/test_csrf_middleware.py
@@ -1,0 +1,261 @@
+"""
+Tests for CSRF protection middleware (__Host- cookies + Origin/Referer validation).
+Module 11b — Penetration Testing Scope: CSRF.
+"""
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+
+from utils.csrf import _normalize_origin, _build_allowlist
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_csrf_cache():
+    """Force csrf module to rebuild its allowlist from current env on next request."""
+    import utils.csrf as m
+    m._allowed_origins = None
+    yield
+    m._allowed_origins = None
+
+
+@pytest.fixture(autouse=True)
+def _disable_rate_limiter(monkeypatch: pytest.MonkeyPatch):
+    """Mock Redis unavailable so the rate-limiter fail-opens for every test.
+    Without this, repeated POSTs to /api/auth/login hit the sliding-window
+    threshold (5 req/15min) and return 429 instead of the expected CSRF or auth response.
+    """
+    async def _mock_redis_unavailable():
+        return None
+    monkeypatch.setattr("main._get_redis", _mock_redis_unavailable)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _enable_csrf(monkeypatch: pytest.MonkeyPatch):
+    """Override the global conftest WIMS_CSRF_DISABLED=1 — CSRF must be active for these tests."""
+    monkeypatch.setenv("WIMS_CSRF_DISABLED", "0")
+    yield
+
+
+CLIENT = TestClient(app)
+
+# ---------------------------------------------------------------------------
+# Unit: URL normalization
+# ---------------------------------------------------------------------------
+
+class TestOriginNormalization:
+    def test_strips_path(self):
+        assert _normalize_origin("https://localhost/callback") == "https://localhost"
+
+    def test_strips_query(self):
+        assert _normalize_origin("http://wimsbfp.tech/api?foo=1") == "http://wimsbfp.tech"
+
+    def test_preserves_port(self):
+        assert _normalize_origin("http://localhost:3000") == "http://localhost:3000"
+
+    def test_https_localhost(self):
+        assert _normalize_origin("https://localhost:443") == "https://localhost:443"
+
+    def test_handles_evil_domain(self):
+        assert _normalize_origin("https://evil.com:8080/path") == "https://evil.com:8080"
+
+
+# ---------------------------------------------------------------------------
+# Unit: allowlist builder
+# ---------------------------------------------------------------------------
+
+class TestAllowlistBuilder:
+    def test_from_csrf_trusted_origins(self):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("CSRF_TRUSTED_ORIGINS", "https://wimsbfp.tech,http://localhost:3000")
+            result = _build_allowlist()
+        assert "https://wimsbfp.tech" in result
+        assert "http://localhost:3000" in result
+
+    def test_falls_back_to_defaults(self):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.delenv("CSRF_TRUSTED_ORIGINS", raising=False)
+            mp.delenv("CSRF_TRUSTED_HOST", raising=False)
+            result = _build_allowlist()
+        assert "http://localhost" in result
+        assert "https://localhost" in result
+
+    def test_from_csrf_trusted_host(self):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.delenv("CSRF_TRUSTED_ORIGINS", raising=False)
+            mp.setenv("CSRF_TRUSTED_HOST", "wimsbfp.tech")
+            result = _build_allowlist()
+        assert "https://wimsbfp.tech" in result
+        assert "http://wimsbfp.tech" in result
+
+
+# ---------------------------------------------------------------------------
+# Integration: safe methods bypass
+# ---------------------------------------------------------------------------
+
+class TestSafeMethods:
+    def test_get_bypasses_csrf(self):
+        resp = CLIENT.get("/health", headers={})
+        assert resp.status_code in (200,)
+
+    def test_head_bypasses_csrf(self):
+        resp = CLIENT.head("/health", headers={})
+        assert resp.status_code in (200, 405)
+
+    def test_options_bypasses_csrf(self):
+        resp = CLIENT.options("/health", headers={})
+        assert resp.status_code in (200, 405)
+
+    def test_get_to_state_changing_route(self):
+        """GET on a state-changing route (not safe-method exempt) — middleware should NOT block."""
+        # GET /api/auth/login doesn't exist but should bypass CSRF
+        resp = CLIENT.get("/api/auth/login", headers={})
+        assert resp.status_code != 403  # Not CSRF-blocked
+
+
+# ---------------------------------------------------------------------------
+# Integration: POST with Origin validation
+# ---------------------------------------------------------------------------
+
+class TestPostOriginValidation:
+    def test_post_rejected_without_origin(self):
+        """POST with neither Origin nor Referer → 403"""
+        resp = CLIENT.post("/api/auth/login", json={}, headers={})
+        assert resp.status_code == 403
+        assert "CSRF validation failed" in resp.text
+
+    def test_post_rejected_invalid_origin(self):
+        """POST from evil.com → 403"""
+        resp = CLIENT.post(
+            "/api/auth/login",
+            json={},
+            headers={"origin": "https://evil.com"},
+        )
+        assert resp.status_code == 403
+        assert "CSRF validation failed" in resp.text
+
+    def test_post_rejected_malformed_origin(self):
+        """POST from gibberish origin → 403"""
+        resp = CLIENT.post(
+            "/api/auth/login",
+            json={},
+            headers={"origin": "this-is-not-a-url"},
+        )
+        assert resp.status_code == 403
+
+    def test_post_accepted_with_valid_origin(self):
+        """POST from localhost → passes CSRF (hits route handler)"""
+        resp = CLIENT.post(
+            "/api/auth/login",
+            json={},
+            headers={"origin": "http://localhost"},
+        )
+        # Should not be 403 — CSRF passed. 401 from stub auth is expected.
+        assert resp.status_code != 403
+        assert resp.status_code == 401
+
+    def test_post_accepted_with_https_localhost(self):
+        """POST from https://localhost → passes CSRF"""
+        resp = CLIENT.post(
+            "/api/auth/login",
+            json={},
+            headers={"origin": "https://localhost"},
+        )
+        assert resp.status_code == 401  # stub auth, not CSRF block
+
+    def test_post_with_referer_valid(self):
+        """POST with only Referer (matching localhost) → passes CSRF"""
+        resp = CLIENT.post(
+            "/api/auth/login",
+            json={},
+            headers={"referer": "http://localhost/login"},
+        )
+        assert resp.status_code == 401  # stub auth, not CSRF block
+
+
+# ---------------------------------------------------------------------------
+# Integration: PUT, PATCH, DELETE
+# ---------------------------------------------------------------------------
+
+class TestOtherUnsafeMethods:
+    def test_put_rejected_invalid_origin(self):
+        """PUT with invalid origin → 403"""
+        resp = CLIENT.put(
+            "/api/auth/login",
+            json={},
+            headers={"origin": "https://evil.com"},
+        )
+        assert resp.status_code == 403
+
+    def test_patch_rejected_invalid_origin(self):
+        """PATCH with invalid origin → 403"""
+        resp = CLIENT.patch(
+            "/api/auth/login",
+            json={},
+            headers={"origin": "https://attacker.org"},
+        )
+        assert resp.status_code == 403
+
+    def test_delete_rejected_invalid_origin(self):
+        """DELETE with invalid origin → 403"""
+        resp = CLIENT.delete(
+            "/api/auth/login",
+            headers={"origin": "https://evil.net"},
+        )
+        assert resp.status_code == 403
+
+    def test_put_accepted_valid_referer(self):
+        """PUT with valid Referer → passes CSRF"""
+        resp = CLIENT.put(
+            "/api/auth/login",
+            json={},
+            headers={"referer": "https://localhost/"},
+        )
+        assert resp.status_code != 403
+
+    def test_patch_accepted_valid_origin(self):
+        """PATCH with valid Origin → passes CSRF"""
+        resp = CLIENT.patch(
+            "/api/auth/login",
+            json={},
+            headers={"origin": "http://localhost"},
+        )
+        assert resp.status_code != 403
+
+
+# ---------------------------------------------------------------------------
+# Integration: VPS production origin
+# ---------------------------------------------------------------------------
+
+class TestProductionOrigin:
+    def test_post_accepted_vps_origin(self):
+        """POST from https://wimsbfp.tech when configured as trusted → passes CSRF"""
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("CSRF_TRUSTED_ORIGINS", "https://wimsbfp.tech")
+            import utils.csrf as m
+            m._allowed_origins = None
+            resp = CLIENT.post(
+                "/api/auth/login",
+                json={},
+                headers={"origin": "https://wimsbfp.tech"},
+            )
+        assert resp.status_code != 403
+
+    def test_post_rejected_vps_port_variation(self):
+        """POST from https://wimsbfp.tech:8443 when only wimsbfp.tech is trusted → 403"""
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("CSRF_TRUSTED_ORIGINS", "https://wimsbfp.tech")
+            import utils.csrf as m
+            m._allowed_origins = None
+            resp = CLIENT.post(
+                "/api/auth/login",
+                json={},
+                headers={"origin": "https://wimsbfp.tech:8443"},
+            )
+        assert resp.status_code == 403

--- a/src/backend/utils/csrf.py
+++ b/src/backend/utils/csrf.py
@@ -47,11 +47,14 @@ def _build_allowlist() -> set[str]:
 
     trusted_host = os.environ.get("CSRF_TRUSTED_HOST", "")
     if trusted_host:
-        # Strip any accidental scheme prefix — CSRF_TRUSTED_HOST should be bare hostname
-        stripped = _normalize_origin(trusted_host) if "://" in trusted_host else trusted_host
-        # Also strip port and path from the normalized value
-        if "://" in stripped:
-            stripped = stripped.split("://", 1)[1]
+        # Strip scheme, port, and path — yield a bare hostname like "wimsbfp.tech"
+        # urlparse requires a scheme to parse hostname correctly; inject a dummy
+        # one when missing so netloc is populated instead of path.
+        raw = trusted_host
+        if "://" not in raw:
+            raw = "//" + raw
+        parsed = urlparse(raw)
+        stripped = parsed.hostname or trusted_host
         origins: set[str] = set()
         for scheme in ("https", "http"):
             origins.add(f"{scheme}://{stripped}")

--- a/src/backend/utils/csrf.py
+++ b/src/backend/utils/csrf.py
@@ -1,0 +1,118 @@
+"""
+CSRF protection middleware — validates Origin/Referer on state-changing requests.
+
+Allows same-origin requests through ONLY when the Origin or Referer header
+matches a configured trusted origin. GET/HEAD/OPTIONS are exempt (safe methods
+per RFC 7231).
+
+Usage:
+    from utils.csrf import CSRFMiddleware
+    app.add_middleware(CSRFMiddleware)
+"""
+
+import logging
+import os
+from urllib.parse import urlparse
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+logger = logging.getLogger("wims.csrf")
+
+SAFE_METHODS = {"GET", "HEAD", "OPTIONS"}
+
+DEFAULT_ORIGINS: set[str] = {
+    "http://localhost",
+    "https://localhost",
+    "http://127.0.0.1",
+    "http://127.0.0.1:3000",
+    "http://localhost:3000",
+    "http://localhost:8000",
+}
+
+
+def _normalize_origin(raw: str) -> str:
+    """Extract scheme + netloc from a URL, stripping path/query/fragment."""
+    parsed = urlparse(raw)
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _build_allowlist() -> set[str]:
+    """Build trusted origin set from environment, falling back to defaults."""
+    env = os.environ.get("CSRF_TRUSTED_ORIGINS", "")
+    if env:
+        origins = {_normalize_origin(o.strip()) for o in env.split(",") if o.strip()}
+        if origins:
+            return origins
+
+    trusted_host = os.environ.get("CSRF_TRUSTED_HOST", "")
+    if trusted_host:
+        # Strip any accidental scheme prefix — CSRF_TRUSTED_HOST should be bare hostname
+        stripped = _normalize_origin(trusted_host) if "://" in trusted_host else trusted_host
+        # Also strip port and path from the normalized value
+        if "://" in stripped:
+            stripped = stripped.split("://", 1)[1]
+        origins: set[str] = set()
+        for scheme in ("https", "http"):
+            origins.add(f"{scheme}://{stripped}")
+        return origins | DEFAULT_ORIGINS
+
+    return DEFAULT_ORIGINS
+
+
+_allowed_origins: set[str] | None = None
+
+
+def _get_allowlist() -> set[str]:
+    global _allowed_origins
+    if _allowed_origins is None:
+        _allowed_origins = _build_allowlist()
+    return _allowed_origins
+
+
+class CSRFMiddleware(BaseHTTPMiddleware):
+    """FastAPI middleware that rejects state-changing requests with untrusted Origin/Referer.
+
+    Disable at runtime by setting WIMS_CSRF_DISABLED=1 in the environment
+    (used during unit tests that do not set Origin/Referer).
+    """
+
+    async def dispatch(self, request, call_next):
+        if os.environ.get("WIMS_CSRF_DISABLED") == "1":
+            return await call_next(request)
+
+        if request.method in SAFE_METHODS:
+            return await call_next(request)
+
+        origin = request.headers.get("origin")
+        referer = request.headers.get("referer")
+
+        source = origin or referer
+        if not source:
+            logger.warning(
+                "CSRF blocked — missing origin header | method=%s path=%s",
+                request.method,
+                request.url.path,
+            )
+            return JSONResponse(
+                status_code=403,
+                content={"detail": "CSRF validation failed: missing origin header"},
+            )
+
+        allowlist = _get_allowlist()
+        normalized = _normalize_origin(source)
+
+        if normalized not in allowlist:
+            logger.warning(
+                "CSRF blocked — untrusted origin | origin=%s normalized=%s method=%s path=%s",
+                source,
+                normalized,
+                request.method,
+                request.url.path,
+            )
+            return JSONResponse(
+                status_code=403,
+                content={"detail": "CSRF validation failed: untrusted origin"},
+            )
+
+        return await call_next(request)

--- a/src/docker-compose.prod.yml
+++ b/src/docker-compose.prod.yml
@@ -6,6 +6,7 @@ services:
   backend:
     environment:
       - KEYCLOAK_ISSUER=${PUBLIC_BASE_URL}/auth/realms/bfp
+      - CSRF_TRUSTED_ORIGINS=${PUBLIC_BASE_URL}
 
   frontend:
     build:

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -137,6 +137,7 @@ services:
       - KEYCLOAK_ADMIN_PASSWORD=admin
       - OLLAMA_URL=http://ollama:11434
       - AFOR_TEMPLATE_PATH=/app/AFOR-FORMATTED.xlsx
+      - CSRF_TRUSTED_ORIGINS=http://localhost,https://localhost,http://127.0.0.1,http://127.0.0.1:3000
     volumes:
       - incident_attachments_data:/app/storage
       - ./postgres-init:/app/postgres-init:ro

--- a/src/frontend/src/app/api/auth/logout/route.ts
+++ b/src/frontend/src/app/api/auth/logout/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 
 export async function POST() {
   const res = NextResponse.json({ ok: true });
-  res.cookies.set('access_token', '', { maxAge: 0, path: '/' });
-  res.cookies.set('refresh_token', '', { maxAge: 0, path: '/' });
+  res.cookies.set('__Host-access_token', '', { maxAge: 0, path: '/' });
+  res.cookies.set('__Host-refresh_token', '', { maxAge: 0, path: '/' });
   return res;
 }

--- a/src/frontend/src/app/api/auth/refresh/route.ts
+++ b/src/frontend/src/app/api/auth/refresh/route.ts
@@ -5,12 +5,18 @@ const KEYCLOAK_TOKEN_URL = process.env.NEXT_PUBLIC_AUTH_API_URL
   : null;
 
 const CLIENT_ID = process.env.NEXT_PUBLIC_OIDC_CLIENT_ID || 'wims-web';
-const IS_PROD = process.env.NODE_ENV === 'production';
 const ACCESS_TOKEN_COOKIE_MAX_AGE = 5 * 60; // 5 minutes: match Keycloak accessTokenLifespan
 const REFRESH_TOKEN_COOKIE_MAX_AGE = 8 * 60 * 60; // 8 hours: match SSO session max
 
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: true,
+  sameSite: 'strict' as const,
+  path: '/',
+};
+
 export async function POST(req: NextRequest) {
-  const refreshToken = req.cookies.get('refresh_token')?.value;
+  const refreshToken = req.cookies.get('__Host-refresh_token')?.value;
   if (!refreshToken) {
     return NextResponse.json({ error: 'No refresh token' }, { status: 401 });
   }
@@ -32,26 +38,20 @@ export async function POST(req: NextRequest) {
 
     if (!res.ok) {
       const response = NextResponse.json({ error: 'Refresh failed' }, { status: 401 });
-      response.cookies.set('access_token', '', { maxAge: 0, path: '/' });
-      response.cookies.set('refresh_token', '', { maxAge: 0, path: '/' });
+      response.cookies.set('__Host-access_token', '', { maxAge: 0, path: '/' });
+      response.cookies.set('__Host-refresh_token', '', { maxAge: 0, path: '/' });
       return response;
     }
 
     const data = await res.json();
     const response = NextResponse.json({ ok: true });
-    response.cookies.set('access_token', data.access_token, {
-      httpOnly: true,
-      secure: IS_PROD,
-      sameSite: 'lax',
-      path: '/',
+    response.cookies.set('__Host-access_token', data.access_token, {
+      ...COOKIE_OPTIONS,
       maxAge: ACCESS_TOKEN_COOKIE_MAX_AGE,
     });
     if (data.refresh_token) {
-      response.cookies.set('refresh_token', data.refresh_token, {
-        httpOnly: true,
-        secure: IS_PROD,
-        sameSite: 'lax',
-        path: '/',
+      response.cookies.set('__Host-refresh_token', data.refresh_token, {
+        ...COOKIE_OPTIONS,
         maxAge: REFRESH_TOKEN_COOKIE_MAX_AGE,
       });
     }

--- a/src/frontend/src/app/api/auth/session/route.test.ts
+++ b/src/frontend/src/app/api/auth/session/route.test.ts
@@ -28,7 +28,7 @@ describe('Session Route — SYSTEM_ADMIN role mapping', () => {
     vi.stubGlobal('fetch', mockFetch);
 
     const req = new NextRequest('http://localhost/api/auth/session', {
-      headers: { cookie: 'access_token=foo' },
+      headers: { cookie: '__Host-access_token=foo' },
     });
 
     const res = await GET(req);

--- a/src/frontend/src/app/api/auth/sync/route.ts
+++ b/src/frontend/src/app/api/auth/sync/route.ts
@@ -13,6 +13,13 @@ function backendUrl(path: string): string {
 const ACCESS_TOKEN_COOKIE_MAX_AGE = 5 * 60; // 5 minutes: match Keycloak accessTokenLifespan
 const REFRESH_TOKEN_COOKIE_MAX_AGE = 8 * 60 * 60; // 8 hours: match SSO session max
 
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: true,
+  sameSite: 'strict' as const,
+  path: '/',
+};
+
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
@@ -20,22 +27,15 @@ export async function POST(req: NextRequest) {
 
     // Accept access_token from client-side signinCallback() flow
     if (access_token) {
-      const IS_PROD = process.env.NODE_ENV === 'production';
       const response = NextResponse.json({ user_id: 'ok' });
-      response.cookies.set('access_token', access_token, {
-        httpOnly: true,
-        secure: IS_PROD,
-        sameSite: 'lax',
-        path: '/',
+      response.cookies.set('__Host-access_token', access_token, {
+        ...COOKIE_OPTIONS,
         maxAge: ACCESS_TOKEN_COOKIE_MAX_AGE,
       });
       const { refresh_token: refreshToken } = body as { refresh_token?: string };
       if (refreshToken) {
-        response.cookies.set('refresh_token', refreshToken, {
-          httpOnly: true,
-          secure: IS_PROD,
-          sameSite: 'lax',
-          path: '/',
+        response.cookies.set('__Host-refresh_token', refreshToken, {
+          ...COOKIE_OPTIONS,
           maxAge: REFRESH_TOKEN_COOKIE_MAX_AGE,
         });
       }
@@ -74,19 +74,13 @@ export async function POST(req: NextRequest) {
     }
 
     const response = NextResponse.json({ user_id: data.user_id });
-    response.cookies.set('access_token', token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      path: '/',
+    response.cookies.set('__Host-access_token', token, {
+      ...COOKIE_OPTIONS,
       maxAge: ACCESS_TOKEN_COOKIE_MAX_AGE,
     });
     if (data.refresh_token) {
-      response.cookies.set('refresh_token', data.refresh_token, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'lax',
-        path: '/',
+      response.cookies.set('__Host-refresh_token', data.refresh_token, {
+        ...COOKIE_OPTIONS,
         maxAge: REFRESH_TOKEN_COOKIE_MAX_AGE,
       });
     }

--- a/src/nginx/nginx.conf
+++ b/src/nginx/nginx.conf
@@ -90,15 +90,16 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             # Keep cookie Domain in sync between nginx-gateway and browser
             proxy_cookie_domain nginx-gateway $host;
-            # CORS headers — backend does not add them, so nginx provides them.
-            add_header Access-Control-Allow-Origin $http_origin always;
+            # CORS headers — same-origin only (CSRF mitigation). The backend does not
+            # add CORS headers, so nginx provides them for same-origin SPA requests.
+            add_header Access-Control-Allow-Origin $scheme://$host always;
             add_header Access-Control-Allow-Credentials true always;
             add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE, OPTIONS' always;
             add_header Access-Control-Allow-Headers 'Authorization, Content-Type, Cookie' always;
 
             # Handle OPTIONS preflight directly — do not proxy to backend.
             if ($request_method = 'OPTIONS') {
-                add_header Access-Control-Allow-Origin $http_origin always;
+                add_header Access-Control-Allow-Origin $scheme://$host always;
                 add_header Access-Control-Allow-Credentials true always;
                 add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE, OPTIONS' always;
                 add_header Access-Control-Allow-Headers 'Authorization, Content-Type, Cookie' always;

--- a/src/nginx/nginx.local.conf
+++ b/src/nginx/nginx.local.conf
@@ -46,13 +46,13 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_cookie_domain nginx-gateway $host;
-            add_header Access-Control-Allow-Origin $http_origin always;
+            add_header Access-Control-Allow-Origin $scheme://$host always;
             add_header Access-Control-Allow-Credentials true always;
             add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE, OPTIONS' always;
             add_header Access-Control-Allow-Headers 'Authorization, Content-Type, Cookie' always;
 
             if ($request_method = 'OPTIONS') {
-                add_header Access-Control-Allow-Origin $http_origin always;
+                add_header Access-Control-Allow-Origin $scheme://$host always;
                 add_header Access-Control-Allow-Credentials true always;
                 add_header Access-Control-Allow-Methods 'GET, POST, PUT, DELETE, OPTIONS' always;
                 add_header Access-Control-Allow-Headers 'Authorization, Content-Type, Cookie' always;

--- a/src/nginx/nginx.local.conf
+++ b/src/nginx/nginx.local.conf
@@ -13,11 +13,33 @@ http {
 
     client_max_body_size 50M;
 
-    # Local development only. Production must use nginx.conf with TLS.
+    # ── HTTP → HTTPS redirect ────────────────────────────────────────────────
     server {
         listen 80;
         listen [::]:80;
         server_name localhost wimsbfp.tech;
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    # ── TLS termination (self-signed certs from .ssl/) ───────────────────────
+    # On first clone, generate certs: see system-wiki/operations/local-dev-deploy-guide.md
+    server {
+        listen 443 ssl;
+        listen [::]:443 ssl;
+        server_name localhost wimsbfp.tech;
+
+        ssl_certificate     /etc/letsencrypt/live/wimsbfp.tech/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/wimsbfp.tech/privkey.pem;
+        ssl_session_timeout 1d;
+        ssl_session_cache   shared:SSL:50m;
+        ssl_session_tickets off;
+        ssl_protocols        TLSv1.2 TLSv1.3;
+        ssl_ciphers          ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
+        ssl_prefer_server_ciphers off;
+        ssl_conf_command Ciphersuites TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256;
 
         add_header X-Content-Type-Options nosniff always;
         add_header X-Frame-Options SAMEORIGIN always;

--- a/system-wiki/gaps/frs-codebase-gap-register.md
+++ b/system-wiki/gaps/frs-codebase-gap-register.md
@@ -39,6 +39,7 @@ This register prevents agents from hallucinating completion. A module is not com
 - **M2b (Offline CRUD — IndexedDB Queue Lifecycle)**: CLOSED — `offlineStore.ts` provides `getQueuedIncident`, `updateQueuedIncident`, `deleteQueuedIncident`, `markSynced`, `getPendingIncidents`; `syncEngine.ts` `syncPendingIncidents` POSTs pending items to backend, marks synced on success, returns `SyncResult { synced, failed, errors }`; closes ISSUE#140.
 - **M2c (Sync Toast Notifications)**: CLOSED — `useAutoSync.ts` `doSync()` dispatches `toast.success`/`toast.warning`/`toast.error` based on `SyncResult` counts; `sonner` added to `package.json`; `<Toaster />` mounted in `layout.tsx`; closes ISSUE#142.
 - **M4b (Verification Audit Hash + Sync Status)**: CLOSED — `40_verification_audit_fields.sql` adds `data_hash TEXT` (SHA-256) and `sync_status TEXT` to `wims.incident_verification_history`; trigger `_insert_incident_verification_history` computes hash on insert; stored procedure `verify_incident_command` records sync status; closes ISSUE#145.
+- **M11b (CSRF Protection)**: CLOSED — SameSite=Strict + `__Host-` prefix on auth cookies (`sync/route.ts`, `refresh/route.ts`, `logout/route.ts`, `auth.py`), Origin/Referer validation middleware (`utils/csrf.py` + registered in `main.py`), nginx CORS restricted to `$scheme://$host`, Docker env vars (`CSRF_TRUSTED_ORIGINS`/`CSRF_TRUSTED_HOST`), CSRF test suite (`tests/test_csrf_middleware.py`), and pen-test checklist (`docs/pentest/CSRF-CHECKLIST.md`).
 
 ## Related
 - [[concepts/frs-module-map]]

--- a/system-wiki/log.md
+++ b/system-wiki/log.md
@@ -1469,9 +1469,9 @@ No schema, auth, or FRS alignment changes.
 - **Cookie hardening (Phase 1):** `__Host-` prefix + `Secure` + `SameSite=Strict` on `__Host-access_token` and `__Host-refresh_token` cookies across 4 route handlers: `sync/route.ts`, `refresh/route.ts`, `logout/route.ts`, and backend `auth.py` read path.
 - **CSRF middleware (Phase 2):** `src/backend/utils/csrf.py` — `CSRFMiddleware` registered in `main.py`. Validates Origin/Referer on POST/PUT/PATCH/DELETE against configurable allowlist. GET/HEAD/OPTIONS bypassed. Logs block events at WARNING level.
 - **Nginx CORS restriction (Phase 3):** `Access-Control-Allow-Origin` changed from `$http_origin` (reflected any origin) to `$scheme://$host` in both `nginx.conf` and `nginx.local.conf`.
-- **Docker env vars (Phase 4):** `CSRF_TRUSTED_ORIGINS` in `docker-compose.yml`, `CSRF_TRUSTED_HOST` in `docker-compose.prod.yml`.
-- **Test suite (Phase 5):** `tests/test_csrf_middleware.py` — 20 test cases covering origin normalization, allowlist builder, safe method bypass, invalid/missing Origin, valid Origin, Referer fallback, PUT/PATCH/DELETE variants, and VPS production origin.
+- **Docker env vars (Phase 4):** `CSRF_TRUSTED_ORIGINS` in `docker-compose.yml` and `docker-compose.prod.yml`.
+- **Test suite (Phase 5):** `tests/test_csrf_middleware.py` — 25 test cases covering origin normalization, allowlist builder, safe method bypass, invalid/missing Origin, valid Origin, Referer fallback, PUT/PATCH/DELETE variants, and VPS production origin.
 - **Pen-test checklist (Phase 6):** `docs/pentest/CSRF-CHECKLIST.md` — cookie attributes, Origin validation steps, cross-origin attack simulation, CORS, OIDC flow integrity, and test coverage verification.
 - **Wiki updates (Phase 7):** This log, `security/security-baseline.md` (new CSRF Protection section), `gaps/frs-codebase-gap-register.md` (M11b CLOSED entry).
 
-**Verification:** `pytest tests/test_csrf_middleware.py -v` — all 20 tests pass.
+**Verification:** `pytest tests/test_csrf_middleware.py -v` — all 25 tests pass.

--- a/system-wiki/log.md
+++ b/system-wiki/log.md
@@ -1459,3 +1459,19 @@ No schema, auth, or FRS alignment changes.
 **Verification:** `curl -I https://wimsbfp.tech/health` returns 200; `curl -I http://wimsbfp.tech/health` returns 301 to HTTPS; nginx mount inspection shows `/etc/letsencrypt -> /etc/letsencrypt` and `src/nginx/nginx.conf -> /etc/nginx/nginx.conf`.
 
 **Wiki updates:** Updated `system-wiki/architecture/infrastructure-config.md`, `system-wiki/operations/local-dev-deploy-guide.md`, and this log. No `system-wiki/gaps/frs-codebase-gap-register.md` update needed; no FRS/codebase gap changed.
+
+## [2026-06-03] implement | M11b CSRF protection — SameSite=Strict, __Host- prefix, Origin/Referer middleware, CORS restrictions
+
+**FRS reference:** Module 11b — Penetration Testing Scope: CSRF (FRS `frs-penentrationtestingandsecurityvalidation.md` 11.b.i.e)
+
+**Changes implemented:**
+
+- **Cookie hardening (Phase 1):** `__Host-` prefix + `Secure` + `SameSite=Strict` on `__Host-access_token` and `__Host-refresh_token` cookies across 4 route handlers: `sync/route.ts`, `refresh/route.ts`, `logout/route.ts`, and backend `auth.py` read path.
+- **CSRF middleware (Phase 2):** `src/backend/utils/csrf.py` — `CSRFMiddleware` registered in `main.py`. Validates Origin/Referer on POST/PUT/PATCH/DELETE against configurable allowlist. GET/HEAD/OPTIONS bypassed. Logs block events at WARNING level.
+- **Nginx CORS restriction (Phase 3):** `Access-Control-Allow-Origin` changed from `$http_origin` (reflected any origin) to `$scheme://$host` in both `nginx.conf` and `nginx.local.conf`.
+- **Docker env vars (Phase 4):** `CSRF_TRUSTED_ORIGINS` in `docker-compose.yml`, `CSRF_TRUSTED_HOST` in `docker-compose.prod.yml`.
+- **Test suite (Phase 5):** `tests/test_csrf_middleware.py` — 20 test cases covering origin normalization, allowlist builder, safe method bypass, invalid/missing Origin, valid Origin, Referer fallback, PUT/PATCH/DELETE variants, and VPS production origin.
+- **Pen-test checklist (Phase 6):** `docs/pentest/CSRF-CHECKLIST.md` — cookie attributes, Origin validation steps, cross-origin attack simulation, CORS, OIDC flow integrity, and test coverage verification.
+- **Wiki updates (Phase 7):** This log, `security/security-baseline.md` (new CSRF Protection section), `gaps/frs-codebase-gap-register.md` (M11b CLOSED entry).
+
+**Verification:** `pytest tests/test_csrf_middleware.py -v` — all 20 tests pass.

--- a/system-wiki/security/security-baseline.md
+++ b/system-wiki/security/security-baseline.md
@@ -44,6 +44,19 @@ All write paths updated: `services/afor_import/commit.py` (AFOR commit), `api/ro
 
 **Remaining GH #150 gaps:** `wims.incident_attachments` filesystem storage unencrypted (GH #151). OpenBao KMS + key rotation pending (GH #152).
 
+## CSRF Protection
+
+FRS Module 11b requires Cross-Site Request Forgery testing. The following layers are enforced:
+
+- **SameSite=Strict cookies:** Auth cookies (`__Host-access_token`, `__Host-refresh_token`) are set with `Secure; HttpOnly; SameSite=Strict; Path=/`. No `Domain` attribute. Implemented in `src/frontend/src/app/api/auth/sync/route.ts`, `refresh/route.ts`, and `logout/route.ts`.
+- **`__Host-` cookie prefix:** Prevents subdomain cookie injection — compliant browsers reject `__Host-` cookies set from any context that does not match the origin exactness requirements (HTTPS, no Domain, Path=/).
+- **Origin/Referer validation middleware:** `src/backend/utils/csrf.py` — `CSRFMiddleware` is registered on the FastAPI app. GET/HEAD/OPTIONS bypass (safe methods). POST/PUT/PATCH/DELETE without a valid Origin or Referer matching the configured allowlist are rejected with 403. Allowlist from `CSRF_TRUSTED_ORIGINS` env var, falling back to `CSRF_TRUSTED_HOST`, falling back to localhost defaults.
+- **Nginx CORS restricted:** `Access-Control-Allow-Origin` set to `$scheme://$host` (not `$http_origin` reflection) in both production and local nginx configs.
+- **Pen-test checklist:** `docs/pentest/CSRF-CHECKLIST.md` documents all manual verification procedures.
+- **Test coverage:** `src/backend/tests/test_csrf_middleware.py` covers safe methods, invalid/missing Origin, valid Origin, Referer fallback, PUT/PATCH/DELETE variants, and VPS production origin scenarios.
+
 ## Related
 - [[database/schema-overview]]
 - [[backend/api-route-map]]
+- [[gaps/frs-codebase-gap-register]]
+- `docs/pentest/CSRF-CHECKLIST.md`


### PR DESCRIPTION
M11b — CSRF Protection Middleware (#173)
Summary
Three-layer CSRF defense per FRS Module 11b: SameSite=Strict + __Host- cookie prefix, Origin/Referer validation middleware, and nginx CORS restriction to $scheme://$host.

##Changes
- Cookie hardening (sync/route.ts, refresh/route.ts, logout/route.ts, auth.py) — Auth cookies renamed from access_token/refresh_token to __Host-access_token/__Host-refresh_token; SameSite changed from lax to strict; Secure set to true in all environments.
- utils/csrf.py — CSRFMiddleware: validates Origin/Referer on POST/PUT/PATCH/DELETE against configurable allowlist (CSRF_TRUSTED_ORIGINS env var); safe methods (GET/HEAD/OPTIONS) bypass; blocks with 403 + WARNING log.
- main.py — app.add_middleware(CSRFMiddleware) registered.
- Nginx CORS (nginx.conf, nginx.local.conf) — Access-Control-Allow-Origin from $http_origin (wildcard) to $scheme://$host.
- docker-compose.yml — CSRF_TRUSTED_ORIGINS for local dev. docker-compose.prod.yml — CSRF_TRUSTED_ORIGINS=${PUBLIC_BASE_URL}.
- tests/test_csrf_middleware.py — 25 tests covering origin normalization, safe method bypass, invalid/missing/valid Origin, Referer fallback, PUT/PATCH/DELETE, production origin scenarios.
- conftest.py — global WIMS_CSRF_DISABLED=1 fixture so existing tests (which don't send Origin) continue passing; CSRF tests explicitly re-enable.
- docs/pentest/CSRF-CHECKLIST.md — manual verification checklist for cookie attributes, cross-origin simulation, CORS, OIDC flow.

##Verification
- tests/test_csrf_middleware.py — 25/25 pass.
- Full pytest -v — 429 passed, 10 skipped (pre-existing M4b data_hash migration gap, unrelated).
- Frontend npx vitest run src/app/api/auth/session/route.test.ts — 2/2 pass.
- Manual curl: cross-origin POST → 403, same-origin POST → 401 (stub auth), missing Origin POST → 403.

##Notes / deferred
- WIMS_CSRF_DISABLED=1 env var toggles middleware off for non-CSRF tests. CSRF tests set it back to 0.
- No database migration or new dependencies required.
- Wiki updated: security-baseline.md, frs-codebase-gap-register.md (M11b CLOSED), log.md.

Closes #173 