### PR TITLE
fix(keycloak): MFA setup page styling — closes #231

### DIFF
--- a/src/frontend/src/__tests__/totp-setup-styling.test.ts
+++ b/src/frontend/src/__tests__/totp-setup-styling.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Reproduction test for Issue #231: MFA TOTP setup page styling broken.
+ *
+ * The .wims-totp-grid-layout uses unbalanced fr values (0.9fr / 1.25fr)
+ * that starve the left (instructions) column. The fix rebalances to
+ * ~equal fr values: 1fr / 1.15fr.
+ *
+ * This test reads the real Keycloak theme CSS, builds the TOTP setup
+ * HTML structure from login-config-totp.ftl, and asserts the computed
+ * grid-template-columns matches the post-fix expected value.
+ *
+ * On the unmodified base commit, this test MUST FAIL because the CSS
+ * still has the old unbalanced values.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+/** Find a CSSStyleRule by exact selector text from the first stylesheet. */
+function findCssRule(doc: Document, selector: string): CSSStyleRule | null {
+  const ss = doc.styleSheets[0];
+  if (!ss) return null;
+  for (let i = 0; i < ss.cssRules.length; i++) {
+    const rule = ss.cssRules[i] as CSSStyleRule;
+    if (rule.selectorText === selector) return rule;
+  }
+  return null;
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const CSS_PATH = resolve(
+  __dirname,
+  '../../../keycloak/themes/wims-bfp/login/resources/css/wims-custom.css',
+);
+
+function readThemeCss(): string {
+  return readFileSync(CSS_PATH, 'utf-8');
+}
+
+function buildTotpSetupDOM(): Document {
+  const css = readThemeCss();
+
+  // Minimal HTML matching the login-config-totp.ftl structure
+  const html = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body>
+  <div class="wims-totp-setup">
+    <div class="wims-totp-grid-layout">
+      <section class="wims-totp-guidance">
+        <h2>Setup Instructions</h2>
+        <ol class="wims-totp-steps">
+          <li>
+            <span class="wims-totp-step-number">1</span>
+            <div><p>Step 1 description</p></div>
+          </li>
+          <li>
+            <span class="wims-totp-step-number">2</span>
+            <div><p>Step 2 description</p></div>
+          </li>
+          <li>
+            <span class="wims-totp-step-number">3</span>
+            <div><p>Step 3 description</p></div>
+          </li>
+        </ol>
+      </section>
+      <section class="wims-totp-entry"></section>
+    </div>
+  </div>
+</body>
+</html>`;
+
+  const dom = new JSDOM(html);
+  const style = dom.window.document.createElement('style');
+  style.textContent = css;
+  dom.window.document.head.appendChild(style);
+
+  return dom.window.document;
+}
+
+describe('TOTP Setup Page Styling (Issue #231)', () => {
+  it('grid-template-columns on .wims-totp-grid-layout should use balanced fr values', () => {
+    const doc = buildTotpSetupDOM();
+    const grid = doc.querySelector('.wims-totp-grid-layout') as HTMLElement;
+    const styles = doc.defaultView!.getComputedStyle(grid);
+
+    // Post-fix expected: left column gets 1fr (was 0.9fr), right gets 1.15fr (was 1.25fr).
+    // This prevents the left (instructions) column from being visually starved.
+    expect(styles.gridTemplateColumns).toBe(
+      'minmax(260px, 1fr) minmax(310px, 1.15fr)',
+    );
+  });
+
+  it('gap on .wims-totp-steps > li should be widened to 0.6rem', () => {
+    const doc = buildTotpSetupDOM();
+    const li = doc.querySelector('.wims-totp-steps > li') as HTMLElement;
+    const styles = doc.defaultView!.getComputedStyle(li);
+
+    // Post-fix: gap widened from 0.45rem to 0.6rem for breathing room.
+    expect(styles.gap).toBe('0.6rem');
+  });
+
+  it('padding on .wims-totp-setup should use two-value clamp shorthand', () => {
+    // jsdom cannot parse clamp(), so verify the raw CSS source.
+    const css = readThemeCss();
+    const match = css.match(/\.wims-totp-setup\s*\{[^}]+padding:\s*([^;!]+)/);
+    expect(match).not.toBeNull();
+
+    // Post-fix: padding raised with two-value shorthand (vertical, horizontal).
+    expect(match![1].trim()).toBe(
+      'clamp(0.85rem, 1.6vw, 1.1rem) clamp(0.7rem, 1.2vw, 0.95rem)',
+    );
+  });
+
+  it('width and height on .wims-totp-step-number should be widened to 1.55rem', () => {
+    const doc = buildTotpSetupDOM();
+    const stepNumber = doc.querySelector('.wims-totp-step-number') as HTMLElement;
+    const styles = doc.defaultView!.getComputedStyle(stepNumber);
+
+    // Post-fix: step circles widened from 1.35rem to 1.55rem.
+    // jsdom reports the raw declared value for fixed rem dimensions.
+    expect(styles.width).toBe('1.55rem');
+    expect(styles.height).toBe('1.55rem');
+  });
+
+  it('line-height on .wims-totp-steps p should be increased to 1.35', () => {
+    const doc = buildTotpSetupDOM();
+    // jsdom has a specificity quirk where the global p !important overrides
+    // the more-specific .wims-totp-steps p !important. Inspect the CSS rule directly.
+    const rule = findCssRule(doc, '.wims-totp-steps p, .wims-totp-entry p');
+    expect(rule).not.toBeNull();
+
+    // Post-fix: line-height increased from 1.25 to 1.35 for readability.
+    expect(rule!.style.lineHeight).toBe('1.35');
+  });
+});

--- a/src/keycloak/themes/wims-bfp/login/resources/css/wims-custom.css
+++ b/src/keycloak/themes/wims-bfp/login/resources/css/wims-custom.css
@@ -518,13 +518,13 @@ input[type="checkbox"] {
     border: 1px solid #e5e7eb !important;
     border-radius: 12px !important;
     box-shadow: 0 8px 24px rgba(15,23,42,0.08) !important;
-    padding: clamp(0.7rem, 1.2vw, 0.95rem) !important;
+    padding: clamp(0.85rem, 1.6vw, 1.1rem) clamp(0.7rem, 1.2vw, 0.95rem) !important;
     margin: 0 auto !important;
 }
 
 .wims-totp-grid-layout {
     display: grid !important;
-    grid-template-columns: minmax(250px, 0.9fr) minmax(330px, 1.25fr) !important;
+    grid-template-columns: minmax(260px, 1fr) minmax(310px, 1.15fr) !important;
     gap: clamp(0.65rem, 1.5vw, 1rem) !important;
     align-items: start !important;
 }
@@ -547,25 +547,25 @@ input[type="checkbox"] {
 
 .wims-totp-steps > li {
     display: grid !important;
-    grid-template-columns: 1.35rem minmax(0, 1fr) !important;
-    gap: 0.45rem !important;
+    grid-template-columns: 1.55rem minmax(0, 1fr) !important;
+    gap: 0.6rem !important;
     align-items: start !important;
     border-left: 3px solid #e2e8f0 !important;
     border-radius: 6px !important;
     background: #ffffff !important;
-    padding: 0.25rem 0.35rem !important;
+    padding: 0.35rem 0.5rem !important;
 }
 
 .wims-totp-step-number {
     display: inline-flex !important;
     align-items: center !important;
     justify-content: center !important;
-    width: 1.35rem !important;
-    height: 1.35rem !important;
+    width: 1.55rem !important;
+    height: 1.55rem !important;
     border-radius: 999px !important;
     background: #992222 !important;
     color: #ffffff !important;
-    font-size: 0.72rem !important;
+    font-size: 0.75rem !important;
     font-weight: 700 !important;
 }
 
@@ -574,7 +574,7 @@ input[type="checkbox"] {
     margin: 0 !important;
     color: #475569 !important;
     font-size: 0.8rem !important;
-    line-height: 1.25 !important;
+    line-height: 1.35 !important;
 }
 
 #kc-totp-supported-apps {


### PR DESCRIPTION
## Problem
The Keycloak MFA (TOTP) setup page at `/auth/realms/bfp/account/` has broken styling. The setup instructions card is clipped on the left edge — step numbers and text are cut off at the card boundary.

## Root cause
- `.wims-totp-grid-layout` used unbalanced fr values (0.9fr / 1.25fr) starving the left column
- `.wims-totp-steps > li` grid column too narrow (1.35rem) causing step number circles to clip
- Insufficient padding/gap around step items

## Fix
5 targeted CSS changes in `wims-custom.css`:
1. Grid columns rebalanced: `minmax(260px, 1fr) minmax(310px, 1.15fr)`
2. Card padding floor raised: `clamp(0.85rem, 1.6vw, 1.1rem)`
3. Step grid widened: 1.55rem column, 0.6rem gap, 0.35rem/0.5rem padding
4. Step circles enlarged: 1.55rem, font 0.75rem
5. Step text line-height loosened: 1.35

## Test evidence
- **Base fail:** grid-template-columns test fails with old `0.9fr/1.25fr` values
- **Patch pass:** 5 vitest assertions all green (grid, gap, padding, width/height, line-height)
- **Mechanical gates:** ruff check ✅, ruff format ✅, eslint ✅

## Changed files
- `src/keycloak/themes/wims-bfp/login/resources/css/wims-custom.css` (+9/-9)
- `src/frontend/src/__tests__/totp-setup-styling.test.ts` (+141 new, 5 tests)

closes #231