### PR TITLE
fix(keycloak): correct MFA setup page left-edge clipping in wims-bfp theme (#231)

### DIFF
--- a/src/frontend/src/__tests__/totp-setup-styling.test.ts
+++ b/src/frontend/src/__tests__/totp-setup-styling.test.ts
@@ -113,7 +113,7 @@ describe('TOTP Setup Page Styling (Issue #231)', () => {
 
     // Post-fix: padding raised with two-value shorthand (vertical, horizontal).
     expect(match![1].trim()).toBe(
-      'clamp(0.85rem, 1.6vw, 1.1rem) clamp(0.7rem, 1.2vw, 0.95rem)',
+      'clamp(0.85rem, 1.6vw, 1.1rem) clamp(1.25rem, 2vw, 1.5rem)',
     );
   });
 

--- a/src/keycloak/themes/wims-bfp/login/resources/css/wims-custom.css
+++ b/src/keycloak/themes/wims-bfp/login/resources/css/wims-custom.css
@@ -500,10 +500,15 @@ input[type="checkbox"] {
 
 /* === MFA / TOTP Setup — allow scroll so OTP boxes are always reachable === */
 
-/* The right panel must scroll; overflow:hidden clips the form on short viewports */
+/* The right panel must scroll; overflow:hidden clips the form on short viewports.
+   overflow-x:visible coerces to auto (scrollbar) when overflow-y is non-visible, so
+   keep hidden but raise min horizontal padding so the card's 24px box-shadow blur
+   never reaches the clip boundary (was 0.75rem = 12px, now 1.5rem = 24px). */
 .pf-v5-c-login__main:has(.wims-totp-setup) {
     overflow-y: auto !important;
     overflow-x: hidden !important;
+    padding-left: clamp(1.5rem, 4vw, 4.5rem) !important;
+    padding-right: clamp(1.5rem, 4vw, 4.5rem) !important;
 }
 
 /* Body must not centre-justify — content starts at the top so nothing is pushed below the fold */
@@ -518,7 +523,7 @@ input[type="checkbox"] {
     border: 1px solid #e5e7eb !important;
     border-radius: 12px !important;
     box-shadow: 0 8px 24px rgba(15,23,42,0.08) !important;
-    padding: clamp(0.85rem, 1.6vw, 1.1rem) clamp(0.7rem, 1.2vw, 0.95rem) !important;
+    padding: clamp(0.85rem, 1.6vw, 1.1rem) clamp(1.25rem, 2vw, 1.5rem) !important;
     margin: 0 auto !important;
 }
 
@@ -553,7 +558,7 @@ input[type="checkbox"] {
     border-left: 3px solid #e2e8f0 !important;
     border-radius: 6px !important;
     background: #ffffff !important;
-    padding: 0.35rem 0.5rem !important;
+    padding: 0.35rem 0.5rem 0.35rem 0.9rem !important;
 }
 
 .wims-totp-step-number {

--- a/system-wiki/gaps/functional-bug-register.md
+++ b/system-wiki/gaps/functional-bug-register.md
@@ -14,6 +14,14 @@ Functional bugs reported by teammates during evaluation. All map to M12 User Man
 
 ---
 
+## M1 Auth / Keycloak Theme Bugs
+
+| # | Bug | Detail | Reported By | Status |
+|---|---|---|---|---|
+| F-10 | TOTP setup page left-edge clipping | `.pf-v5-c-login__main` base `overflow: hidden` with min horizontal padding 0.75rem (12px) clips the `.wims-totp-setup` card's box-shadow and step-number circles on desktop. Fix: raised panel min padding to 1.5rem (24px) on TOTP pages via `:has(.wims-totp-setup)` override; raised card left/right padding to `clamp(1.25rem,2vw,1.5rem)`; raised step-item left padding `0.5rem` → `0.9rem`. CSS-only. #231. | Issue triage | Fixed in code; pending visual verify |
+
+---
+
 ## M12 User Management Bugs
 
 | # | Bug | Detail | Reported By | Status |

--- a/system-wiki/log.md
+++ b/system-wiki/log.md
@@ -182,6 +182,12 @@ Format: `## [YYYY-MM-DD] action | subject`
 - Used `vi.useRealTimers()` in the first test so @loadable/component's 200ms delay fires and the dynamic import resolves.
 - All 4 tests pass.
 
+## [2026-06-10] fix | M1 Keycloak theme: TOTP setup page left-edge clipping (#231)
+
+- Root cause: `.pf-v5-c-login__main` base rule had `overflow: hidden` with a min horizontal padding of 0.75rem (12px). On the TOTP page the wide `.wims-totp-setup` card (up to 860px) filled the content area edge-to-edge; its 24px box-shadow blur and the step-number circles were clipped at the panel's left overflow boundary.
+- Fix (CSS-only, `wims-custom.css`): (1) `:has(.wims-totp-setup)` override — raised panel min horizontal padding to 1.5rem (24px) via `padding-left/right: clamp(1.5rem, 4vw, 4.5rem)` (`overflow-x: visible` coerces to `auto` due to CSS spec, producing a horizontal scrollbar — padding raise is the correct approach). (2) `.wims-totp-setup` card left/right padding `clamp(0.7rem,1.2vw,0.95rem)` → `clamp(1.25rem,2vw,1.5rem)`. (3) `.wims-totp-steps > li` left padding `0.5rem` → `0.9rem` so the 1.55rem circles sit fully clear of the card's left border.
+- No migration, no app code, no FTL changes. Validation: visual — restart keycloak, assign "Configure OTP" action to a test user, log in.
+
 ## [2026-06-09] fix | PR #238 rebase + review fixes — 6 files
 
 - Rebased `feat/m13-email-triggers` onto origin/master (1345808). Resolved 2 conflicts:


### PR DESCRIPTION
## Summary

- **Root cause:** The base `.pf-v5-c-login__main` rule has `overflow: hidden` with a minimum horizontal padding of `0.75rem` (12px). On the TOTP setup page, the `.wims-totp-setup` card (up to 860px wide) fills the content area edge-to-edge; its 24px `box-shadow` blur and the step-number circles were being clipped at the panel's left overflow boundary.
- **Fix:** CSS-only — `wims-custom.css`, TOTP selectors only. Three targeted changes; no `login.ftl`-shared rules touched, no FTL file changes, no migration.

## CSS changes

| Selector | Before | After |
|---|---|---|
| `.pf-v5-c-login__main:has(.wims-totp-setup)` | no `padding` override | `padding-left/right: clamp(1.5rem, 4vw, 4.5rem)` — raises min from 12px to 24px so shadow never reaches clip boundary |
| `.wims-totp-setup` | `padding: … clamp(0.7rem,1.2vw,0.95rem)` | `padding: … clamp(1.25rem,2vw,1.5rem)` — wider card left/right inset |
| `.wims-totp-steps > li` | `padding: 0.35rem 0.5rem` | `padding: 0.35rem 0.5rem 0.35rem 0.9rem` — circles sit clear of card left border |

> **Why not `overflow-x: visible`?** CSS spec coerces `overflow-x: visible` to `auto` when `overflow-y` is non-`visible`, which produces a horizontal scrollbar. Raising the padding is the correct approach.

## Validation

Stack uses `start-dev` — themes are **not cached**. Steps:
1. `cd src && docker compose up -d --build`
2. `docker compose restart keycloak` (picks up bind-mounted theme edit)
3. Keycloak admin → `http://localhost:8080/auth/admin` → realm `bfp` → Users → `analyst_test` → Required User Actions → add **Configure OTP** → Save
4. Log out, log in as `analyst_test` / `Password123!` → TOTP setup page renders

### Eyeball checklist
- [ ] Instructions card renders with **no left-edge clipping**
- [ ] Step number circles (1, 2, 3) **fully visible** — not half-cut
- [ ] Text has visible gap from circles
- [ ] QR code and OTP boxes properly aligned
- [ ] Device name field and Submit button fully visible

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)